### PR TITLE
Skip null tracks from spotify and fix matching with empty track names

### DIFF
--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -436,7 +436,7 @@ export function Dashboard() {
                 tracks = playlistTracks.map((t) => t.track)
               }
 
-              const songs: Song[] = tracks.map((track) => ({
+              const songs: Song[] = tracks.filter((t) => t != null).map((track) => ({
                 spotifyTrackId: track.id,
                 title: track.name,
                 album: track.album?.name || "Unknown",
@@ -712,12 +712,12 @@ export function Dashboard() {
 
         if ("isLikedSongs" in item && item.isLikedSongs) {
           const savedTracks = await spotifyClient.getAllSavedTracks(signal)
-          tracks = savedTracks.map((t) => t.track)
+          tracks = savedTracks.map((t) => t.track).filter((t) => t != null)
           isLikedSongs = true
         } else {
           tracks = (await spotifyClient.getAllPlaylistTracks(item.id, signal)).map(
             (t) => t.track,
-          )
+          ).filter((t) => t != null)
 
           // Check for cached export data
           cachedData = loadPlaylistExportData(item.id)

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -52,7 +52,7 @@ export class SpotifyClient {
       offset += limit;
     }
 
-    return allTracks.filter((t) => !!t);
+    return allTracks;
   }
 
   async getSavedTracks(limit: number = 50, offset: number = 0, signal?: AbortSignal, bypassCache: boolean = false): Promise<SpotifySavedTracksResponse> {
@@ -78,7 +78,7 @@ export class SpotifyClient {
       offset += limit;
     }
 
-    return allTracks.filter((t) => !!t);
+    return allTracks;
   }
 
   async getSavedTracksCount(signal?: AbortSignal, bypassCache: boolean = false): Promise<number> {


### PR DESCRIPTION
I tried to export a rather big [playlist](https://open.spotify.com/playlist/4pRYn3s8IG17HzC4sMed4D) (1500+ songs) and there were two weird tracks, that either were null or the title was empty.

I tried to skip those files and avoid an error, so the export will still continue.