### PR TITLE
chore: add .commandcode/taste/ to .gitignore and stop tracking

### DIFF
--- a/.commandcode/taste/taste.md
+++ b/.commandcode/taste/taste.md
@@ -1,3 +1,0 @@
-# git
-- Use feature/fix branches for changes instead of committing directly to the working branch, so changes can be tested before merging. Confidence: 0.60
-- Do not commit without explicit user consent — always ask before running git commit. Confidence: 0.85

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # config
 opencode.json
+
+# taste
+.commandcode/taste/


### PR DESCRIPTION
Adds `.commandcode/taste/` to `.gitignore` and removes the taste file from tracking.

Co-authored-by: CommandCodeBot <noreply@commandcode.ai>