### PR TITLE
Merge recovered commits: Spotify retry fixes, matching improvements, export fix, cache bypass

### DIFF
--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -1105,6 +1105,8 @@ export function Dashboard() {
         let isLikedSongs = false
         let cachedData: PlaylistExportData | PlaylistExportDataV2 | undefined = undefined
         let useDifferentialMatching = false
+        let upToDate = false
+        let existingNavidromeId: string | undefined = undefined
 
         if ("isLikedSongs" in item && item.isLikedSongs) {
           const savedTracks = await spotifyClient.getAllSavedTracks(signal)
@@ -1127,10 +1129,30 @@ export function Dashboard() {
 
           // Check for cached export data
           cachedData = loadPlaylistExportData(item.id)
-          const upToDate = cachedData
+          existingNavidromeId = cachedData?.navidromePlaylistId
+
+          // If localStorage has no record, query Navidrome server for a linked playlist
+          if (!existingNavidromeId && !forceExportPlaylists) {
+            const serverPlaylist = await navidromeClient.getPlaylistByComment(item.id)
+            if (serverPlaylist) {
+              existingNavidromeId = serverPlaylist.id
+              cachedData = {
+                spotifyPlaylistId: item.id,
+                spotifySnapshotId: itemSnapshotId,
+                playlistName: item.name,
+                navidromePlaylistId: serverPlaylist.id,
+                exportedAt: new Date().toISOString(),
+                trackCount: 0,
+                tracks: {},
+                statistics: { total: 0, matched: 0, unmatched: 0, ambiguous: 0 },
+              }
+            }
+          }
+
+          upToDate = cachedData
             ? isPlaylistUpToDate(cachedData, itemSnapshotId)
             : false
-          const hasNavidromePlaylist = !!cachedData?.navidromePlaylistId
+          const hasNavidromePlaylist = !!existingNavidromeId
           useDifferentialMatching = !forceExportPlaylists && hasNavidromePlaylist
         }
 
@@ -1383,7 +1405,17 @@ export function Dashboard() {
           }
         }
 
-        if (isLikedSongs) {
+        // Skip unchanged playlists entirely (no tracks added/removed)
+        if (upToDate && existingNavidromeId && !forceExportPlaylists && !isLikedSongs) {
+          exportResultData = {
+            statistics: {
+              total: tracks.length,
+              starred: tracks.length,
+              skipped: 0,
+              failed: 0,
+            },
+          }
+        } else if (isLikedSongs) {
           const result = await favoritesExporter.exportFavorites(matches, {
             skipUnmatched: false,
             signal,
@@ -1627,6 +1659,19 @@ export function Dashboard() {
             setTrackExportCache((prev) =>
               new Map(prev).set(item.id, updatedCache),
             )
+
+            // Persist the link to the Navidrome playlist comment for cross-browser identity
+            try {
+              await navidromeClient.updatePlaylistComment(result.playlistId, {
+                spotifyPlaylistId: item.id,
+                navidromePlaylistId: result.playlistId,
+                spotifySnapshotId: itemSnapshotId,
+                exportedAt: updatedCache.exportedAt,
+                trackCount: tracks.length,
+              }, signal)
+            } catch (e) {
+              console.warn('Failed to update playlist comment:', e)
+            }
           }
         }
 

--- a/lib/export/playlist-exporter.ts
+++ b/lib/export/playlist-exporter.ts
@@ -221,7 +221,8 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
           checkAbort();
 
           const existingTracks = await this.navidromeClient.getPlaylist(options.existingPlaylistId, signal);
-          const existingSongIds = existingTracks.tracks.map(t => t.id);
+          const existingSongIds = existingTracks.tracks.map(t => t.mediaFileId || t.id);
+          const existingIdSet = new Set(existingSongIds);
 
           if (arraysEqual(existingSongIds, songIds)) {
             exported = songIds.length;
@@ -229,15 +230,41 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
             break;
           }
 
-          const replaceResult = await this.navidromeClient.replacePlaylistSongs(options.existingPlaylistId, songIds, signal);
-          if (!replaceResult.success) {
-            errors.push({
-              trackName: 'N/A',
-              artistName: 'N/A',
-              reason: `Failed to replace tracks: ${replaceResult.error || 'Unknown error'}`,
-            });
-            break;
+          // Only add songs that aren't already in the playlist
+          const newSongIds = songIds.filter(id => !existingIdSet.has(id));
+          const removedEntryIndices = existingTracks.tracks
+            .map((t, i) => ({ mediaFileId: t.mediaFileId || t.id, index: i }))
+            .filter(({ mediaFileId }) => !songIds.includes(mediaFileId))
+            .map(({ index }) => index);
+
+          if (newSongIds.length > 0) {
+            const addResult = await this.navidromeClient.updatePlaylist(
+              options.existingPlaylistId, newSongIds, undefined, signal
+            );
+            if (!addResult.success) {
+              errors.push({
+                trackName: 'N/A',
+                artistName: 'N/A',
+                reason: `Failed to add new tracks: ${addResult.error || 'Unknown error'}`,
+              });
+              break;
+            }
           }
+
+          if (removedEntryIndices.length > 0) {
+            const removeResult = await this.navidromeClient.updatePlaylist(
+              options.existingPlaylistId, [], removedEntryIndices, signal
+            );
+            if (!removeResult.success) {
+              errors.push({
+                trackName: 'N/A',
+                artistName: 'N/A',
+                reason: `Failed to remove stale tracks: ${removeResult.error || 'Unknown error'}`,
+              });
+              break;
+            }
+          }
+
           exported = songIds.length;
           playlistId = options.existingPlaylistId;
           break;

--- a/lib/matching/fuzzy.test.ts
+++ b/lib/matching/fuzzy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateTrackSimilarity, findBestMatch, normalizeTitle, normalizeArtistName } from '@/lib/matching/fuzzy';
+import { calculateTrackSimilarity, findBestMatch, normalizeTitle, normalizeArtistName, calculateBestArtistSimilarity, calculateAlbumSimilarity, normalizeString, hasVersionMismatch, extractVersionMarkers } from '@/lib/matching/fuzzy';
 import { SpotifyTrack } from '@/types/spotify';
 import { NavidromeSong } from '@/types/navidrome';
 
@@ -149,5 +149,234 @@ describe('normalizeArtistName', () => {
   it('normalizes collaboration indicators', () => {
     const name = normalizeArtistName('Artist Ft. Guest');
     expect(name).not.toContain('ft.');
+  });
+});
+
+describe('calculateBestArtistSimilarity', () => {
+  it('returns 1.0 when any individual artist matches exactly', () => {
+    const score = calculateBestArtistSimilarity(['Kendrick Lamar', 'SZA'], 'Kendrick Lamar');
+    expect(score).toBe(1.0);
+  });
+
+  it('scores higher than joined-string comparison for multi-artist tracks', () => {
+    const bestScore = calculateBestArtistSimilarity(['Kendrick Lamar', 'SZA'], 'Kendrick Lamar');
+    const joinedScore = calculateBestArtistSimilarity(['Kendrick Lamar SZA'], 'Kendrick Lamar');
+    expect(bestScore).toBeGreaterThan(joinedScore);
+  });
+
+  it('returns 0 when no artists overlap', () => {
+    const score = calculateBestArtistSimilarity(['Drake', 'Future'], 'Kendrick Lamar');
+    expect(score).toBeLessThan(0.5);
+  });
+});
+
+describe('per-artist matching in calculateTrackSimilarity', () => {
+  it('matches multi-artist Spotify track against single-artist Navidrome song', () => {
+    const multiArtistTrack: SpotifyTrack = {
+      id: 'sp2',
+      name: 'All The Stars',
+      uri: 'spotify:track:sp2',
+      artists: [{ id: 'a1', name: 'Kendrick Lamar' }, { id: 'a2', name: 'SZA' }],
+      album: { id: 'al1', name: 'Black Panther' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const navidromeSong: NavidromeSong = {
+      id: 'nd1',
+      title: 'All The Stars',
+      artist: 'Kendrick Lamar',
+      album: 'Black Panther',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(multiArtistTrack, navidromeSong);
+    expect(score).toBeGreaterThan(0.9);
+  });
+});
+
+describe('album similarity cap removed', () => {
+  it('returns raw token ratio without 0.8 multiplier', () => {
+    const score = calculateAlbumSimilarity('Same Album', 'Same Album');
+    expect(score).toBe(1.0);
+  });
+
+  it('returns proportional ratio for partial matches', () => {
+    const score = calculateAlbumSimilarity('Greatest Hits Vol 1', 'Greatest Hits');
+    expect(score).toBeGreaterThan(0.5);
+    expect(score).toBeLessThanOrEqual(1.0);
+  });
+});
+
+describe('article prefix stripping in normalizeString', () => {
+  it('strips leading "the"', () => {
+    expect(normalizeString('The Weeknd')).toBe('weeknd');
+  });
+
+  it('strips leading "a"', () => {
+    expect(normalizeString('A Tribe Called Quest')).toBe('tribe called quest');
+  });
+
+  it('strips leading "an"', () => {
+    expect(normalizeString('An Animal')).toBe('animal');
+  });
+
+  it('does not strip articles in the middle of a string', () => {
+    expect(normalizeString('Getting the Thing')).toBe('getting the thing');
+  });
+
+  it('does not strip articles at the end of a string', () => {
+    expect(normalizeString('Meet The')).toBe('meet the');
+  });
+});
+
+describe('artist gate', () => {
+  it('rejects wrong-artist match with same title', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp1',
+      name: 'Stay Another Night',
+      uri: 'spotify:track:sp1',
+      artists: [{ id: 'a1', name: 'Chris Ayer' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const wrongCandidate: NavidromeSong = {
+      id: 'nd1',
+      title: 'Stay Another Night',
+      artist: 'Cheat Codes',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, wrongCandidate);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('still matches correct artist with same title', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp1',
+      name: 'Stay Another Night',
+      uri: 'spotify:track:sp1',
+      artists: [{ id: 'a1', name: 'Chris Ayer' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const correctCandidate: NavidromeSong = {
+      id: 'nd1',
+      title: 'Stay Another Night',
+      artist: 'Chris Ayer',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, correctCandidate);
+    expect(score).toBeGreaterThan(0.8);
+  });
+});
+
+describe('version mismatch penalty', () => {
+  it('rejects remix matching original', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp2',
+      name: 'Love Me Like That',
+      uri: 'spotify:track:sp2',
+      artists: [{ id: 'a1', name: 'State of Sound' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const remixCandidate: NavidromeSong = {
+      id: 'nd2',
+      title: 'Love Me Like That (Landis Remix)',
+      artist: 'State of Sound',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, remixCandidate);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('rejects acoustic matching original', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp3',
+      name: 'Some Song',
+      uri: 'spotify:track:sp3',
+      artists: [{ id: 'a1', name: 'Some Artist' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const acousticCandidate: NavidromeSong = {
+      id: 'nd3',
+      title: 'Some Song (Acoustic)',
+      artist: 'Some Artist',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, acousticCandidate);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('rejects live matching original', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp4',
+      name: 'Some Song',
+      uri: 'spotify:track:sp4',
+      artists: [{ id: 'a1', name: 'Some Artist' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const liveCandidate: NavidromeSong = {
+      id: 'nd4',
+      title: 'Some Song (Live)',
+      artist: 'Some Artist',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, liveCandidate);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('still matches when both have the same version marker', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp5',
+      name: 'Some Song (Remix)',
+      uri: 'spotify:track:sp5',
+      artists: [{ id: 'a1', name: 'Some Artist' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const remixCandidate: NavidromeSong = {
+      id: 'nd5',
+      title: 'Some Song (Remix)',
+      artist: 'Some Artist',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, remixCandidate);
+    expect(score).toBeGreaterThan(0.8);
+  });
+});
+
+describe('hasVersionMismatch', () => {
+  it('detects mismatch when one has remix and other does not', () => {
+    expect(hasVersionMismatch('Song', 'Song (Remix)')).toBe(true);
+    expect(hasVersionMismatch('Song (Remix)', 'Song')).toBe(true);
+  });
+
+  it('detects no mismatch when both lack version markers', () => {
+    expect(hasVersionMismatch('Song', 'Song')).toBe(false);
+  });
+
+  it('detects no mismatch when both have same version marker', () => {
+    expect(hasVersionMismatch('Song (Remix)', 'Song (Remix)')).toBe(false);
+  });
+
+  it('detects mismatch when versions differ (remix vs live)', () => {
+    expect(hasVersionMismatch('Song (Remix)', 'Song (Live)')).toBe(true);
+  });
+
+  it('does not false-positive on titles without version markers in parentheses', () => {
+    expect(hasVersionMismatch('Live Your Life', 'Live Your Life')).toBe(false);
   });
 });

--- a/lib/matching/fuzzy.ts
+++ b/lib/matching/fuzzy.ts
@@ -25,7 +25,8 @@ export function normalizeString(str: string): string {
     .replace(/[\u0300-\u036f]/g, '')
     .replace(/[^\w\s]/g, '')
     .replace(/\s+/g, ' ')
-    .trim();
+    .trim()
+    .replace(/^(the|a|an)\s+/, '');
 }
 
 export function levenshteinDistance(a: string, b: string): number {
@@ -88,6 +89,19 @@ export function calculateArtistSimilarity(
   return 1.0 - distance / maxLength;
 }
 
+export function calculateBestArtistSimilarity(
+  spotifyArtists: string[],
+  navidromeArtist: string
+): number {
+  let best = 0;
+  for (const artist of spotifyArtists) {
+    const score = calculateArtistSimilarity(artist, navidromeArtist);
+    if (score > best) best = score;
+    if (best === 1.0) break;
+  }
+  return best;
+}
+
 const DURATION_THRESHOLD_MS = 3000;
 
 export function calculateDurationSimilarity(
@@ -109,27 +123,6 @@ export function calculateDurationSimilarity(
 const SOUNDTRACK_WORDS = [
   'original', 'sound', 'track', 'ost', ' soundtrack', 'score',
   'complete', 'vol', 'volume', ' disc ', 'disk'
-];
-
-const LIVE_INDICATORS = [
-  ' (live)',
-  '- live',
-  ' [live]',
-  ' live',
-  '(live)',
-  '-live',
-  '[live]',
-];
-
-const COLLABORATION_INDICATORS = [
-  'feat', 'feat.', 'ft', 'ft.',
-  'with', ' x ', ' X ',
-  ' and ', ' & ',
-  ' vs ', ' versus ',
-  ' presents ', ' presenting ',
-  ' pres. ', ' pres ',
-  ' prod ', ' produced by ',
-  'DJ '
 ];
 
 const TITLE_SUFFIX_PATTERN = /[\(\[].*?[\)\]]\s*$|[-–—~/].*$/;
@@ -160,18 +153,21 @@ export function normalizeTitle(title: string): string {
   // Remove parenthetical/bracket groups containing featured artists
   // e.g. "(feat. Kehlani & Lil Yachty)", "[ft. Someone]"
   normalized = normalized.replace(FEATURED_ARTIST_PATTERN, ' ');
-  for (const indicator of LIVE_INDICATORS) {
-    normalized = normalized.replace(new RegExp(indicator.replace(/[[\]()]/g, '\\$&'), 'gi'), ' ');
-  }
   normalized = normalizeString(normalized);
   return normalized.replace(/\s+/g, ' ').trim();
 }
 
+const COLLABORATION_INDICATORS_AMBIGUOUS = /\s+[xX]\s+|\s+&\s+|\s+and\s+/g;
+
 export function normalizeArtistName(artist: string): string {
   let normalized = artist.toLowerCase();
-  for (const indicator of COLLABORATION_INDICATORS) {
-    normalized = normalized.replace(new RegExp(indicator.replace(/[[\]()]/g, '\\$&'), 'gi'), ' ');
-  }
+  // Strip clear collaboration indicators and everything after them
+  // e.g. "Kendrick Lamar feat. SZA" → "kendrick lamar"
+  normalized = normalized.replace(/\s+(?:feat\.?|ft\.?|featuring|with|vs\.?|versus|presents?\.?|presenting|prod\.?|produced by)\s.*$/gi, '');
+  // Remove ambiguous collaboration indicators (keep surrounding text)
+  normalized = normalized.replace(COLLABORATION_INDICATORS_AMBIGUOUS, ' ');
+  // Remove "DJ " prefix
+  normalized = normalized.replace(/^dj\s+/gi, '');
   normalized = normalizeString(normalized);
   return normalized.replace(/\s+/g, ' ').trim();
 }
@@ -195,7 +191,7 @@ export function calculateAlbumSimilarity(
   );
 
   const similarity = matchingParts.length / Math.max(spotifyParts.length, navidromeParts.length);
-  return similarity * 0.8;
+  return similarity;
 }
 
 export function calculateTitleSimilarity(
@@ -216,6 +212,38 @@ export function calculateTitleSimilarity(
   return 1.0 - distance / maxLength;
 }
 
+const VERSION_KEYWORDS = /\b(?:remix|rmxx|acoustic|instrumental|radio\s*edit|extended|dub|vip|rework|bootleg|karaoke|demo|unplugged|stripped|live|mix|edit|cover)\b/gi;
+
+export function extractVersionMarkers(title: string): Set<string> {
+  const markers = new Set<string>();
+  const groups = title.match(/[\(\[][^\)\]]*[\)\]]/g) || [];
+  for (const group of groups) {
+    const matches = group.match(VERSION_KEYWORDS);
+    if (matches) matches.forEach(m => markers.add(m.toLowerCase()));
+  }
+  const dashParts = title.split(/[-–—]/);
+  if (dashParts.length > 1) {
+    for (let i = 1; i < dashParts.length; i++) {
+      const matches = dashParts[i].match(VERSION_KEYWORDS);
+      if (matches) matches.forEach(m => markers.add(m.toLowerCase()));
+    }
+  }
+  return markers;
+}
+
+export function hasVersionMismatch(spotifyTitle: string, navidromeTitle: string): boolean {
+  const spotifyMarkers = extractVersionMarkers(spotifyTitle);
+  const navidromeMarkers = extractVersionMarkers(navidromeTitle);
+
+  if (spotifyMarkers.size === 0 && navidromeMarkers.size === 0) return false;
+  if (spotifyMarkers.size === 0 || navidromeMarkers.size === 0) return true;
+
+  for (const m of spotifyMarkers) {
+    if (navidromeMarkers.has(m)) return false;
+  }
+  return true;
+}
+
 export function calculateTrackSimilarity(
   spotifyTrack: import('@/types/spotify').SpotifyTrack,
   navidromeSong: import('@/types/navidrome').NavidromeSong
@@ -224,8 +252,8 @@ export function calculateTrackSimilarity(
   const hasSpotifyAlbum = spotifyTrack.album && spotifyTrack.album.name && spotifyTrack.album.name.length > 0;
 
   const artistSimilarity = hasSpotifyArtist
-    ? calculateArtistSimilarity(
-        spotifyTrack.artists.map((a) => a.name).join(' '),
+    ? calculateBestArtistSimilarity(
+        spotifyTrack.artists.map((a) => a.name),
         navidromeSong.artist
       )
     : -1;
@@ -263,19 +291,26 @@ export function calculateTrackSimilarity(
 
   let baseSimilarity = availableWeight > 0 ? weightedSum / availableWeight : titleSimilarity;
 
-  if (titleSimilarity === 1.0 && (artistSimilarity < 0 || artistSimilarity >= 0.3)) {
-    return Math.max(
-      (artistSimilarity >= 0 ? artistSimilarity * 0.2 : 0) + titleSimilarity * 0.4 + durationSimilarity * 0.3 + (albumSimilarity >= 0 ? albumSimilarity * 0.1 : 0),
-      0.85
-    );
+  if (titleSimilarity === 1.0 && (artistSimilarity < 0 || artistSimilarity >= 0.6)) {
+    baseSimilarity = (artistSimilarity >= 0 ? artistSimilarity * 0.2 : 0) + titleSimilarity * 0.4 + durationSimilarity * 0.3 + (albumSimilarity >= 0 ? albumSimilarity * 0.1 : 0);
   }
 
-  if (durationSimilarity >= 0.9 && (artistSimilarity < 0 || artistSimilarity >= 0.3)) {
+  if (durationSimilarity >= 0.9 && (artistSimilarity < 0 || artistSimilarity >= 0.6)) {
     baseSimilarity = Math.min(baseSimilarity + 0.1, 0.95);
   }
 
-  if (albumSimilarity >= 0.8 && titleSimilarity >= 0.6 && (artistSimilarity < 0 || artistSimilarity >= 0.4)) {
+  if (albumSimilarity >= 0.8 && titleSimilarity >= 0.6 && (artistSimilarity < 0 || artistSimilarity >= 0.6)) {
     baseSimilarity = Math.min(baseSimilarity + 0.05, 0.95);
+  }
+
+  // Artist gate: reject candidates with significantly different artists
+  if (artistSimilarity >= 0 && artistSimilarity < 0.6) {
+    baseSimilarity = Math.min(baseSimilarity, 0.5);
+  }
+
+  // Version mismatch penalty: reject different versions (remix vs original, live vs original, etc.)
+  if (hasVersionMismatch(spotifyTrack.name, navidromeSong.title)) {
+    baseSimilarity = Math.min(baseSimilarity, 0.5);
   }
 
   return baseSimilarity;

--- a/lib/matching/orchestrator.ts
+++ b/lib/matching/orchestrator.ts
@@ -84,6 +84,19 @@ export async function matchTrack(
   let nativeCandidates: NavidromeNativeSong[] = [];
 
   nativeCandidates = await client.searchByTitle(trackTitle, opts.maxSearchResults, signal);
+
+  if (nativeCandidates.length > 50 && spotifyTrack.artists?.length > 0) {
+    const narrowed = await client.searchByTitleAndArtist(
+      trackTitle,
+      spotifyTrack.artists[0].name,
+      opts.maxSearchResults,
+      signal,
+    );
+    if (narrowed.length > 0) {
+      nativeCandidates = narrowed;
+    }
+  }
+
   candidates = nativeCandidates.map(convertNativeSongToNavidromeSong);
 
   const spotifyDurationSec = spotifyTrack.duration_ms / 1000;
@@ -164,7 +177,7 @@ export async function matchTrack(
   }
 
   if (opts.enableStrict) {
-    const strictResult = await matchByStrict(client, spotifyTrack);
+    const strictResult = await matchByStrict(client, spotifyTrack, nativeCandidates, signal);
     strategyResults.push({
       strategy: 'strict',
       matched: strictResult.status === 'matched',

--- a/lib/matching/strict-matcher.test.ts
+++ b/lib/matching/strict-matcher.test.ts
@@ -49,3 +49,86 @@ describe('filterStrictMatches', () => {
     expect(result).toHaveLength(0);
   });
 });
+
+describe('collaboration indicator handling', () => {
+  it('matches artist with feat. suffix to plain artist', () => {
+    const featSong: NavidromeNativeSong = {
+      id: 's4',
+      title: 'Test Song',
+      artist: 'Test Artist feat. Guest',
+      artistId: 'a4',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    const result = filterStrictMatches([featSong], 'test artist', 'test song');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s4');
+  });
+
+  it('matches Spotify artist with feat. to plain Navidrome artist', () => {
+    const plainSong: NavidromeNativeSong = {
+      id: 's5',
+      title: 'Test Song',
+      artist: 'Test Artist',
+      artistId: 'a5',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    // matchByStrict normalizes 'Test Artist feat. Guest' → 'test artist' before calling filterStrictMatches
+    const result = filterStrictMatches([plainSong], 'test artist', 'test song');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s5');
+  });
+});
+
+describe('featured artist in title', () => {
+  it('matches title with feat. annotation to plain title', () => {
+    const featTitleSong: NavidromeNativeSong = {
+      id: 's6',
+      title: 'Hit Song (feat. Someone)',
+      artist: 'Test Artist',
+      artistId: 'a6',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    const result = filterStrictMatches([featTitleSong], 'test artist', 'hit song');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s6');
+  });
+});
+
+describe('version mismatch detection', () => {
+  it('rejects version mismatch when normalized titles match', () => {
+    const liveSong: NavidromeNativeSong = {
+      id: 's7',
+      title: 'Test Song (Live)',
+      artist: 'Test Artist',
+      artistId: 'a7',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    // Both "Test Song Live" and "Test Song (Live)" normalize to "test song live"
+    // but only the Navidrome version has a version marker in parentheses
+    const result = filterStrictMatches([liveSong], 'test artist', 'test song live', 'Test Song Live');
+    expect(result).toHaveLength(0);
+  });
+
+  it('matches when both have same version marker', () => {
+    const remixSong: NavidromeNativeSong = {
+      id: 's8',
+      title: 'Test Song (Remix)',
+      artist: 'Test Artist',
+      artistId: 'a8',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    const result = filterStrictMatches([remixSong], 'test artist', 'test song remix', 'Test Song (Remix)');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s8');
+  });
+});

--- a/lib/matching/strict-matcher.ts
+++ b/lib/matching/strict-matcher.ts
@@ -4,26 +4,32 @@ import { NavidromeApiClient } from '@/lib/navidrome/client';
 import { NavidromeNativeSong } from '@/types/navidrome';
 import { convertNativeSongToNavidromeSong } from './orchestrator';
 import { trackKey as getTrackKey } from '@/lib/spotify/track-identity';
+import { normalizeTitle as normalizeTitleFuzzy, normalizeArtistName as normalizeArtistNameFuzzy, hasVersionMismatch } from './fuzzy';
 
 export function normalizeString(str: string): string {
   return str
     .toLowerCase()
     .replace(/[^a-z0-9\s]/g, '')
     .replace(/\s+/g, ' ')
-    .trim();
+    .trim()
+    .replace(/^(the|a|an)\s+/, '');
 }
 
 export function filterStrictMatches(
   songs: NavidromeNativeSong[],
   normalizedArtist: string | null,
-  normalizedTitle: string
+  normalizedTitle: string,
+  rawSpotifyTitle?: string
 ): NavidromeNativeSong[] {
   return songs.filter((song) => {
-    const songTitle = normalizeString(song.title);
+    const songTitle = normalizeTitleFuzzy(song.title);
     if (songTitle !== normalizedTitle) return false;
-    if (normalizedArtist === null) return true;
-    const songArtist = normalizeString(song.artist);
-    return songArtist === normalizedArtist;
+    if (normalizedArtist !== null) {
+      const songArtist = normalizeArtistNameFuzzy(song.artist);
+      if (songArtist !== normalizedArtist) return false;
+    }
+    if (rawSpotifyTitle && hasVersionMismatch(rawSpotifyTitle, song.title)) return false;
+    return true;
   });
 }
 
@@ -36,9 +42,9 @@ export async function matchByStrict(
   const tk = getTrackKey(spotifyTrack);
   const hasArtist = spotifyTrack.artists && spotifyTrack.artists.length > 0 && spotifyTrack.artists.some(a => a.name.trim().length > 0);
   const normalizedArtist = hasArtist
-    ? normalizeString(spotifyTrack.artists.map((a) => a.name).join(' '))
+    ? normalizeArtistNameFuzzy(spotifyTrack.artists.map((a) => a.name).join(' '))
     : null;
-  const normalizedTitle = normalizeString(spotifyTrack.name);
+  const normalizedTitle = normalizeTitleFuzzy(spotifyTrack.name);
 
   if (!normalizedTitle) {
     return {
@@ -52,7 +58,7 @@ export async function matchByStrict(
 
   try {
     const songs = candidates || await client.searchByTitle(spotifyTrack.name, 100, signal);
-    const matches = filterStrictMatches(songs, normalizedArtist, normalizedTitle);
+    const matches = filterStrictMatches(songs, normalizedArtist, normalizedTitle, spotifyTrack.name);
 
     if (matches.length === 0) {
       return {

--- a/lib/navidrome/client.ts
+++ b/lib/navidrome/client.ts
@@ -261,15 +261,22 @@ export class NavidromeApiClient {
         _order: 'ASC',
       };
 
-      const response = await this._makeNativeRequest<{
-        items: NavidromePlaylist[];
-      }>('/api/playlist', params, signal);
+      const response = await this._makeNativeRequest<NavidromePlaylist[] | { items: NavidromePlaylist[] }>('/api/playlist', params, signal);
 
-      if (response.items && response.items.length > 0) {
-        allPlaylists.push(...response.items.map(this._mapPlaylist));
+      let items: NavidromePlaylist[];
+      if (Array.isArray(response)) {
+        items = response;
+      } else if (response.items) {
+        items = response.items;
+      } else {
+        items = [];
       }
 
-      if (allPlaylists.length >= this._totalCount || !response.items || response.items.length === 0) {
+      if (items.length > 0) {
+        allPlaylists.push(...items.map(this._mapPlaylist));
+      }
+
+      if (allPlaylists.length >= this._totalCount || items.length === 0) {
         break;
       }
 
@@ -286,13 +293,20 @@ export class NavidromeApiClient {
     const playlistResponse = await this._makeNativeRequest<NavidromePlaylist>(`/api/playlist/${playlistId}`, {}, signal);
     const playlist = this._mapPlaylist(playlistResponse);
 
-    const tracksResponse = await this._makeNativeRequest<{
-      items: NavidromeNativeSong[];
-    }>(`/api/playlist/${playlistId}/tracks`, { _start: 0, _end: 1000 }, signal);
+    const tracksResponse = await this._makeNativeRequest<NavidromeNativeSong[] | { items: NavidromeNativeSong[] }>(`/api/playlist/${playlistId}/tracks`, { _start: 0, _end: 1000 }, signal);
+
+    let tracks: NavidromeNativeSong[];
+    if (Array.isArray(tracksResponse)) {
+      tracks = tracksResponse;
+    } else if (tracksResponse.items) {
+      tracks = tracksResponse.items;
+    } else {
+      tracks = [];
+    }
 
     return {
       playlist,
-      tracks: tracksResponse.items || [],
+      tracks,
     };
   }
 

--- a/lib/navidrome/client.ts
+++ b/lib/navidrome/client.ts
@@ -537,6 +537,22 @@ export class NavidromeApiClient {
     return songs;
   }
 
+  async searchByTitleAndArtist(title: string, artistName: string, limit?: number, signal?: AbortSignal): Promise<NavidromeNativeSong[]> {
+    const end = limit || 50;
+    const strippedTitle = stripTitleSuffix(title);
+
+    const artist = await this.getArtistByName(artistName);
+    if (!artist) return [];
+
+    let songs = await this.searchByQuery('', { title: strippedTitle, artistId: artist.id, _start: 0, _end: end }, signal);
+
+    if (songs.length === 0 && title !== strippedTitle) {
+      songs = await this.searchByQuery('', { title, artistId: artist.id, _start: 0, _end: end }, signal);
+    }
+
+    return songs;
+  }
+
   async getSongByTitle(title: string): Promise<NavidromeNativeSong | null> {
     try {
       const params: Record<string, string | number | undefined> = {

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -272,16 +272,30 @@ export class SpotifyClient {
       fetchOptions.cache = 'no-store';
     }
 
-    const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, fetchOptions);
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, fetchOptions);
 
-    if (response.status === 401) {
-      const refreshed = await this.refreshAccessToken();
-      if (refreshed) {
-        return this.fetch(endpoint, signal, options, bypassCache);
+      if (response.status === 401) {
+        const refreshed = await this.refreshAccessToken();
+        if (refreshed) {
+          return this.fetch(endpoint, signal, options, bypassCache);
+        }
       }
+
+      if (response.status >= 500 && response.status < 600) {
+        lastError = new Error(`Spotify API error: ${response.status}`);
+        if (attempt < 2) {
+          const delay = Math.pow(2, attempt) * 1000;
+          await new Promise(resolve => setTimeout(resolve, delay));
+          continue;
+        }
+      }
+
+      return response;
     }
 
-    return response;
+    throw lastError || new Error('Spotify API request failed');
   }
 
   clearToken(): void {

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -250,7 +250,7 @@ export class SpotifyClient {
       }
     }
 
-    const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, {
+    const fetchOptions: RequestInit = {
       ...options,
       signal,
       headers: {
@@ -258,7 +258,13 @@ export class SpotifyClient {
         'Content-Type': 'application/json',
         ...options.headers,
       },
-    });
+    };
+
+    if (bypassCache) {
+      fetchOptions.cache = 'no-store';
+    }
+
+    const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, fetchOptions);
 
     if (response.status === 401) {
       const refreshed = await this.refreshAccessToken();

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -201,37 +201,45 @@ export class SpotifyClient {
   async refreshAccessToken(): Promise<SpotifyToken | null> {
     if (!this.token?.refreshToken) return null;
 
-    try {
-      const response = await fetch('/api/auth/refresh', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refreshToken: this.token.refreshToken }),
-      });
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const response = await fetch('/api/auth/refresh', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refreshToken: this.token.refreshToken }),
+        });
 
-      if (!response.ok) return null;
+        if (!response.ok) {
+          if (response.status === 400) return null;
+          throw new Error(`Refresh failed: ${response.status}`);
+        }
 
-      const data = await response.json();
-      const newToken: SpotifyToken = {
-        accessToken: data.access_token,
-        refreshToken: this.token.refreshToken,
-        expiresAt: Date.now() + data.expires_in * 1000,
-        tokenType: data.token_type,
-        scope: data.scope,
-      };
+        const data = await response.json();
+        const newToken: SpotifyToken = {
+          accessToken: data.access_token,
+          refreshToken: this.token.refreshToken,
+          expiresAt: Date.now() + data.expires_in * 1000,
+          tokenType: data.token_type,
+          scope: data.scope,
+        };
 
-      this.setToken(newToken);
-      
-      const stored = localStorage.getItem(SPOTIFY_STORAGE_KEY);
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        parsed.token = newToken;
-        localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(parsed));
+        this.setToken(newToken);
+        
+        const stored = localStorage.getItem(SPOTIFY_STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          parsed.token = newToken;
+          localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(parsed));
+        }
+        
+        return newToken;
+      } catch {
+        if (attempt < 2) {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
       }
-      
-      return newToken;
-    } catch {
-      return null;
     }
+    return null;
   }
 
   private async fetch(endpoint: string, signal?: AbortSignal, options: RequestInit = {}, bypassCache: boolean = false): Promise<Response> {

--- a/types/navidrome.ts
+++ b/types/navidrome.ts
@@ -21,6 +21,7 @@ export interface NavidromeApiConfig {
 
 export interface NavidromeNativeSong {
   id: string;
+  mediaFileId?: string;
   title: string;
   artist: string;
   artistId: string;


### PR DESCRIPTION
Recovers 5 commits that were on local main:

- `fix(dashboard): force cache bypass on playlist refresh`
- `fix(export): stop differential update from re-adding all tracks`
- `fix(matching): reduce false positives for ISRC-less tracks`
- `fix(spotify): retry token refresh before throwing error`
- `fix(spotify): retry 5xx errors and avoid black screen crash`

Co-authored-by: CommandCodeBot <noreply@commandcode.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved playlist synchronization by updating only added or removed tracks instead of replacing entire playlists.
  * Preserved playlist linking information across browsers through Navidrome metadata.
  * Automatically skips unchanged playlists during exports.

* **Bug Fixes**
  * Improved song matching for multiple artists, featured tracks, articles, and alternate versions.
  * Reduced incorrect matches between remixes, live recordings, acoustic versions, and standard tracks.
  * Improved handling of Navidrome responses and Spotify authentication or server failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->