### PR TITLE
fix: address remaining CodeRabbit review findings on PR #18

### DIFF
--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -1030,7 +1030,11 @@ export function Dashboard() {
 
           // If localStorage has no record, query Navidrome server for a linked playlist
           if (!existingNavidromeId && !forceExportPlaylists) {
-            const serverPlaylist = await navidromeClient.getPlaylistByComment(item.id)
+            const lookup = await navidromeClient.findPlaylistBySpotifyId(item.id)
+            if (lookup.error) {
+              throw lookup.error
+            }
+            const serverPlaylist = lookup.playlist
             if (serverPlaylist) {
               existingNavidromeId = serverPlaylist.id
               const serverMetadata = parseExportMetadata(serverPlaylist.comment)
@@ -1308,8 +1312,8 @@ export function Dashboard() {
           exportResultData = {
             statistics: {
               total: tracks.length,
-              starred: tracks.length,
-              skipped: 0,
+              starred: statistics.matched,
+              skipped: tracks.length - statistics.matched,
               failed: 0,
             },
           }

--- a/lib/export/playlist-exporter.ts
+++ b/lib/export/playlist-exporter.ts
@@ -222,26 +222,21 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
 
           const existingTracks = await this.navidromeClient.getPlaylist(options.existingPlaylistId, signal);
           const existingSongIds = existingTracks.tracks.map(t => t.mediaFileId || t.id);
-          const existingIdSet = new Set(existingSongIds);
+
+          // Set playlistId up-front so partial failures don't leave the caller
+          // without the id to reference when surfacing errors.
+          playlistId = options.existingPlaylistId;
 
           if (arraysEqual(existingSongIds, songIds)) {
             exported = songIds.length;
-            playlistId = options.existingPlaylistId;
             break;
           }
 
-          // Only add songs that aren't already in the playlist
-          playlistId = options.existingPlaylistId;
-          const newSongIds = songIds.filter(id => !existingIdSet.has(id));
-          const songIdSet = new Set(songIds);
-          const removedEntryIndices = existingTracks.tracks
-            .map((t, i) => ({ mediaFileId: t.mediaFileId || t.id, index: i }))
-            .filter(({ mediaFileId }) => !songIdSet.has(mediaFileId))
-            .map(({ index }) => index);
+          const appendTail = isOrderedPrefixAppend(existingSongIds, songIds);
 
-          if (newSongIds.length > 0) {
+          if (appendTail) {
             const addResult = await this.navidromeClient.updatePlaylist(
-              options.existingPlaylistId, newSongIds, undefined, signal
+              options.existingPlaylistId, appendTail, undefined, signal
             );
             if (!addResult.success) {
               errors.push({
@@ -251,22 +246,23 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
               });
               break;
             }
+            exported = songIds.length;
+            break;
           }
 
-          if (removedEntryIndices.length > 0) {
-            const removeResult = await this.navidromeClient.updatePlaylist(
-              options.existingPlaylistId, [], removedEntryIndices, signal
-            );
-            if (!removeResult.success) {
-              errors.push({
-                trackName: 'N/A',
-                artistName: 'N/A',
-                reason: `Failed to remove stale tracks: ${removeResult.error || 'Unknown error'}`,
-              });
-              break;
-            }
+          // Reorder, gap, or count decrease — replace the full list so the final
+          // sequence exactly matches songIds.
+          const replaceResult = await this.navidromeClient.replacePlaylistSongs(
+            options.existingPlaylistId, songIds, signal
+          );
+          if (!replaceResult.success) {
+            errors.push({
+              trackName: 'N/A',
+              artistName: 'N/A',
+              reason: `Failed to replace playlist: ${replaceResult.error || 'Unknown error'}`,
+            });
+            break;
           }
-
           exported = songIds.length;
           break;
         }
@@ -346,4 +342,12 @@ function arraysEqual(a: string[], b: string[]): boolean {
     if (a[i] !== b[i]) return false;
   }
   return true;
+}
+
+function isOrderedPrefixAppend(existing: string[], desired: string[]): string[] | null {
+  if (desired.length <= existing.length) return null;
+  for (let i = 0; i < existing.length; i++) {
+    if (existing[i] !== desired[i]) return null;
+  }
+  return desired.slice(existing.length);
 }

--- a/lib/matching/fuzzy.test.ts
+++ b/lib/matching/fuzzy.test.ts
@@ -379,4 +379,9 @@ describe('hasVersionMismatch', () => {
   it('does not false-positive on titles without version markers in parentheses', () => {
     expect(hasVersionMismatch('Live Your Life', 'Live Your Life')).toBe(false);
   });
+
+  it('detects mismatch when markers partially overlap (Extended Mix vs Radio Edit Mix)', () => {
+    expect(hasVersionMismatch('Song (Extended Mix)', 'Song (Radio Edit Mix)')).toBe(true);
+    expect(hasVersionMismatch('Song (Extended Mix)', 'Song (Extended Mix) (Radio Edit Mix)')).toBe(true);
+  });
 });

--- a/lib/matching/fuzzy.ts
+++ b/lib/matching/fuzzy.ts
@@ -238,10 +238,11 @@ export function hasVersionMismatch(spotifyTitle: string, navidromeTitle: string)
   if (spotifyMarkers.size === 0 && navidromeMarkers.size === 0) return false;
   if (spotifyMarkers.size === 0 || navidromeMarkers.size === 0) return true;
 
+  if (spotifyMarkers.size !== navidromeMarkers.size) return true;
   for (const m of spotifyMarkers) {
-    if (navidromeMarkers.has(m)) return false;
+    if (!navidromeMarkers.has(m)) return true;
   }
-  return true;
+  return false;
 }
 
 export function calculateTrackSimilarity(

--- a/lib/matching/strict-matcher.test.ts
+++ b/lib/matching/strict-matcher.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { filterStrictMatches } from '@/lib/matching/strict-matcher';
+import { describe, it, expect, vi } from 'vitest';
+import { filterStrictMatches, matchByStrict } from '@/lib/matching/strict-matcher';
 import { NavidromeNativeSong } from '@/types/navidrome';
+import type { SpotifyTrack } from '@/types/spotify';
+import type { NavidromeApiClient } from '@/lib/navidrome/client';
 
 const song1: NavidromeNativeSong = {
   id: 's1',
@@ -130,5 +132,41 @@ describe('version mismatch detection', () => {
     const result = filterStrictMatches([remixSong], 'test artist', 'test song remix', 'Test Song (Remix)');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('s8');
+  });
+});
+
+describe('matchByStrict', () => {
+  const plainSong: NavidromeNativeSong = {
+    id: 'm1',
+    title: 'Hit Song',
+    artist: 'Test Artist',
+    artistId: 'a9',
+    album: 'Album',
+    albumId: 'al1',
+    duration: 180,
+  };
+
+  function makeMockClient(): NavidromeApiClient {
+    return {
+      searchByTitle: vi.fn().mockResolvedValue([plainSong]),
+      searchByTitleAndArtist: vi.fn().mockResolvedValue([plainSong]),
+      searchByQuery: vi.fn().mockResolvedValue([plainSong]),
+    } as unknown as NavidromeApiClient;
+  }
+
+  it('normalizes "Test Artist feat. Guest" before matching a plain Navidrome artist', async () => {
+    const client = makeMockClient();
+    const spotifyTrack: SpotifyTrack = {
+      id: 'st1',
+      name: 'Hit Song',
+      artists: [{ name: 'Test Artist feat. Guest' }],
+      album: { name: 'Album' },
+      duration_ms: 180000,
+    } as SpotifyTrack;
+
+    const result = await matchByStrict(client, spotifyTrack);
+    expect(result.status).toBe('matched');
+    expect(result.navidromeSong?.id).toBe('m1');
+    expect(client.searchByTitle).toHaveBeenCalled();
   });
 });

--- a/lib/navidrome/client.ts
+++ b/lib/navidrome/client.ts
@@ -541,7 +541,7 @@ export class NavidromeApiClient {
     const end = limit || 50;
     const strippedTitle = stripTitleSuffix(title);
 
-    const artist = await this.getArtistByName(artistName);
+    const artist = await this.getArtistByName(artistName, signal);
     if (!artist) return [];
 
     let songs = await this.searchByQuery('', { title: strippedTitle, artistId: artist.id, _start: 0, _end: end }, signal);
@@ -573,7 +573,7 @@ export class NavidromeApiClient {
     }
   }
 
-  async getArtistByName(artistName: string): Promise<NavidromeNativeArtist | null> {
+  async getArtistByName(artistName: string, signal?: AbortSignal): Promise<NavidromeNativeArtist | null> {
     try {
       const params: Record<string, string | number | undefined> = {
         name: artistName,
@@ -583,14 +583,17 @@ export class NavidromeApiClient {
 
       const response = await this._makeNativeRequest<{
         items: NavidromeNativeArtist[];
-      }>('/api/artist', params);
+      }>('/api/artist', params, signal);
 
       if (response.items && response.items.length > 0) {
         return response.items[0];
       }
 
       return null;
-    } catch {
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw err;
+      }
       return null;
     }
   }
@@ -834,19 +837,27 @@ export class NavidromeApiClient {
   }
 
   async getPlaylistByComment(spotifyPlaylistId: string): Promise<NavidromePlaylist | null> {
+    const result = await this.findPlaylistBySpotifyId(spotifyPlaylistId);
+    return result.playlist;
+  }
+
+  async findPlaylistBySpotifyId(spotifyPlaylistId: string): Promise<{ playlist: NavidromePlaylist | null; error?: Error }> {
     try {
       const playlists = await this.getPlaylists();
 
       for (const playlist of playlists) {
         const metadata = parseExportMetadata(playlist.comment);
         if (metadata && metadata.spotifyPlaylistId === spotifyPlaylistId) {
-          return playlist;
+          return { playlist };
         }
       }
 
-      return null;
-    } catch {
-      return null;
+      return { playlist: null };
+    } catch (err) {
+      return {
+        playlist: null,
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
     }
   }
 

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -210,7 +210,7 @@ export class SpotifyClient {
         });
 
         if (!response.ok) {
-          if (response.status === 400) return null;
+          if (response.status >= 400 && response.status < 500) return null;
           throw new Error(`Refresh failed: ${response.status}`);
         }
 
@@ -224,14 +224,14 @@ export class SpotifyClient {
         };
 
         this.setToken(newToken);
-        
+
         const stored = localStorage.getItem(SPOTIFY_STORAGE_KEY);
         if (stored) {
           const parsed = JSON.parse(stored);
           parsed.token = newToken;
           localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(parsed));
         }
-        
+
         return newToken;
       } catch {
         if (attempt < 2) {
@@ -277,11 +277,14 @@ export class SpotifyClient {
       const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, fetchOptions);
 
       if (response.status === 401) {
-        const refreshed = await this.refreshAccessToken();
-        if (refreshed) {
-          return this.fetch(endpoint, signal, options, bypassCache);
+        if (attempt >= 2) {
+          throw new Error('Spotify token refresh failed (401 after retry)');
         }
-        throw new Error('Token expired and refresh failed');
+        const refreshed = await this.refreshAccessToken();
+        if (!refreshed) {
+          throw new Error('Token expired and refresh failed');
+        }
+        continue;
       }
 
       if (response.status >= 500 && response.status < 600) {


### PR DESCRIPTION
Resolves the remaining actionable CodeRabbit review findings on PR #18.

- playlist-exporter: ordered prefix-append or full replace on diff
- Dashboard: distinguish lookup error vs not-found; count only matched
- fuzzy: hasVersionMismatch requires complete marker equivalence + test
- navidrome: getArtistByName accepts/forwards AbortSignal
- spotify: refresh no retry on 4xx; 401 refresh at most once + throws
- strict-matcher test: matchByStrict for feat. normalization

Tests 53/53, tsc clean, no new lint errors in changed files.