### PR TITLE
fix(auth): clear Spotify session on logout

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -19,6 +19,8 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ authenticated: true, token: decoded });
   } catch {
-    return NextResponse.json({ authenticated: false, error: 'invalid_token' });
+    const response = NextResponse.json({ authenticated: false, error: 'invalid_token' });
+    response.cookies.delete('spotify_token');
+    return response;
   }
 }

--- a/app/api/auth/spotify/route.ts
+++ b/app/api/auth/spotify/route.ts
@@ -46,6 +46,7 @@ export async function DELETE() {
   
   response.cookies.delete('spotify_auth_state');
   response.cookies.delete('spotify_code_verifier');
+  response.cookies.delete('spotify_token');
   
   return response;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { SpotifyConnectButton } from "@/components/spotify-connect-button"
 import { SkipSpotifyButton } from "@/components/skip-spotify-button"
 import { NavidromeCredentialsForm } from "@/components/navidrome-credentials-form"
 import { ErrorBoundary } from "@/components/ErrorBoundary"
+import { LoadingScreen } from "@/components/LoadingScreen"
 import Image from "next/image"
 import NavispotLogo from "@/public/navispot.png"
 
@@ -38,14 +39,7 @@ export default function Home() {
   const { isLoading, spotify, navidrome, skipSpotify } = useAuth()
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-black">
-        <div className="flex flex-col items-center gap-4">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-green-500 border-t-transparent" />
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">Loading...</p>
-        </div>
-      </div>
-    )
+    return <LoadingScreen />
   }
 
   const isAuthenticated = skipSpotify || (navidrome.isConnected && spotify.isAuthenticated)

--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -105,22 +105,26 @@ function formatDuration(ms: number): string {
 }
 
 export function Dashboard() {
-  const { spotify, navidrome, spotifyLogout, setSkipSpotify } = useAuth()
+  const {
+    spotify,
+    navidrome,
+    spotifyLogout,
+    setSkipSpotify,
+    playlists,
+    navidromePlaylists,
+    likedSongsCount,
+    fetchError,
+    refreshing,
+    refreshData,
+  } = useAuth()
   const toast = useToast()
-  const [playlists, setPlaylists] = useState<SpotifyPlaylist[]>([])
   const [tableItems, setTableItems] = useState<PlaylistTableItem[]>([])
   const [importedPlaylists, setImportedPlaylists] = useState<ImportedPlaylist[]>(() =>
     getJSON<ImportedPlaylist[]>(IMPORTED_STORAGE_KEY, []),
   )
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [progressState, setProgressState] = useState<ProgressState | null>(null)
-  const [likedSongsCount, setLikedSongsCount] = useState<number>(0)
-  const [refreshing, setRefreshing] = useState(false)
-  const [navidromePlaylists, setNavidromePlaylists] = useState<
-    NavidromePlaylist[]
-  >([])
 
   const [isExporting, setIsExporting] = useState(false)
   const [showConfirmation, setShowConfirmation] = useState(false)
@@ -173,67 +177,6 @@ export function Dashboard() {
   // Tracks playlist ids whose tracks are currently being fetched. Lives in a
   // ref (not state) so the fetch effect doesn't re-fire on every setState.
   const tracksFetchInFlightRef = useRef<Set<string>>(new Set())
-
-  useEffect(() => {
-    async function fetchData() {
-      if (!spotify.isAuthenticated || !spotify.token) {
-        setError(null)
-        return
-      }
-
-      setLoading(true)
-      setError(null)
-
-      try {
-        spotifyClient.setToken(spotify.token)
-        const fetchedPlaylists = await spotifyClient.getAllPlaylists()
-        setPlaylists(fetchedPlaylists)
-
-        try {
-          const count = await spotifyClient.getSavedTracksCount()
-          setLikedSongsCount(count)
-        } catch {
-          setLikedSongsCount(0)
-        }
-
-        if (
-          navidrome.isConnected &&
-          navidrome.credentials &&
-          navidrome.token &&
-          navidrome.clientId
-        ) {
-          const navidromeClient = new NavidromeApiClient(
-            navidrome.credentials.url,
-            navidrome.credentials.username,
-            navidrome.credentials.password,
-            navidrome.token,
-            navidrome.clientId,
-          )
-          try {
-            const navPlaylists = await navidromeClient.getPlaylists()
-            setNavidromePlaylists(navPlaylists)
-          } catch (navErr) {
-            console.warn("Failed to fetch Navidrome playlists:", navErr)
-          }
-        }
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : "Failed to fetch playlists",
-        )
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchData()
-  }, [
-    spotify.isAuthenticated,
-    spotify.token,
-    navidrome.isConnected,
-    navidrome.credentials,
-    navidrome.token,
-    navidrome.clientId,
-  ])
 
   useEffect(() => {
     setJSON(IMPORTED_STORAGE_KEY, importedPlaylists)
@@ -328,102 +271,56 @@ export function Dashboard() {
   }, [importedPlaylists, toast])
 
   const handleRefreshPlaylists = async () => {
-    setRefreshing(true)
     setError(null)
 
+    const oldTrackCounts = new Map(playlists.map(p => [p.id, p.items.total]))
+    const oldSnapshots = new Map(playlists.map(p => [p.id, p.snapshot_id]))
+
     try {
-      if (spotify.isAuthenticated && spotify.token) {
-        spotifyClient.setToken(spotify.token)
+      await refreshData()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to refresh playlists")
+    }
 
-        // Capture old track counts AND snapshot IDs for comparison
-        const oldTrackCounts = new Map(
-          playlists.map(p => [p.id, p.items.total])
-        )
-        const oldSnapshots = new Map(
-          playlists.map(p => [p.id, p.snapshot_id])
-        )
+    const changedPlaylistIds = playlists
+      .filter(p => oldSnapshots.has(p.id))
+      .filter(p => {
+        const trackCountChanged = oldTrackCounts.get(p.id) !== p.items.total
+        const snapshotChanged = oldSnapshots.get(p.id) !== p.snapshot_id
+        return trackCountChanged || snapshotChanged
+      })
+      .map(p => p.id)
 
-        const fetchedPlaylists = await spotifyClient.getAllPlaylists(undefined, true)
+    if (changedPlaylistIds.length > 0) {
+      setPlaylistTracksCache(prev => {
+        const newCache = new Map(prev)
+        changedPlaylistIds.forEach(id => newCache.delete(id))
+        return newCache
+      })
+    }
 
-        // Compare both track counts AND snapshot IDs - playlist changed if either is different
-        const changedPlaylistIds = fetchedPlaylists
-          .filter(p => oldSnapshots.has(p.id))
-          .filter(p => {
-            const trackCountChanged = oldTrackCounts.get(p.id) !== p.items.total
-            const snapshotChanged = oldSnapshots.get(p.id) !== p.snapshot_id
-            return trackCountChanged || snapshotChanged
-          })
-          .map(p => p.id)
-
-        if (changedPlaylistIds.length > 0) {
-          setPlaylistTracksCache(prev => {
-            const newCache = new Map(prev)
-            changedPlaylistIds.forEach(id => newCache.delete(id))
-            return newCache
-          })
-        }
-
-        setPlaylists(fetchedPlaylists)
-
+    if (importedPlaylists.length > 0) {
+      const updated: ImportedPlaylist[] = []
+      for (const existing of importedPlaylists) {
         try {
-          const count = await spotifyClient.getSavedTracksCount(undefined, true)
-          setLikedSongsCount(count)
-        } catch {
-          setLikedSongsCount(0)
-        }
-      }
-
-      // Re-fetch each imported playlist to pick up the latest tracks/metadata
-      if (importedPlaylists.length > 0) {
-        const updated: ImportedPlaylist[] = []
-        for (const existing of importedPlaylists) {
-          try {
-            const res = await fetch("/api/spotify/public-playlist", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                url: `https://open.spotify.com/playlist/${existing.id}`,
-              }),
-            })
-            if (res.ok) {
-              const data = await res.json()
-              updated.push(data.playlist as ImportedPlaylist)
-            } else {
-              updated.push(existing)
-            }
-          } catch {
+          const res = await fetch("/api/spotify/public-playlist", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              url: `https://open.spotify.com/playlist/${existing.id}`,
+            }),
+          })
+          if (res.ok) {
+            const data = await res.json()
+            updated.push(data.playlist as ImportedPlaylist)
+          } else {
             updated.push(existing)
           }
-        }
-        setImportedPlaylists(updated)
-      }
-
-      if (
-        navidrome.isConnected &&
-        navidrome.credentials &&
-        navidrome.token &&
-        navidrome.clientId
-      ) {
-        const navidromeClient = new NavidromeApiClient(
-          navidrome.credentials.url,
-          navidrome.credentials.username,
-          navidrome.credentials.password,
-          navidrome.token,
-          navidrome.clientId,
-        )
-        try {
-          const navPlaylists = await navidromeClient.getPlaylists()
-          setNavidromePlaylists(navPlaylists)
-        } catch (navErr) {
-          console.warn("Failed to fetch Navidrome playlists:", navErr)
+        } catch {
+          updated.push(existing)
         }
       }
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to refresh playlists",
-      )
-    } finally {
-      setRefreshing(false)
+      setImportedPlaylists(updated)
     }
   }
 
@@ -1979,7 +1876,7 @@ export function Dashboard() {
       isExporting={isExporting}
       onRefresh={handleRefreshPlaylists}
       isRefreshing={refreshing}
-      loading={loading}
+      loading={false}
       onClear={handleClearImported}
       canClear={importedPlaylists.length > 0}
       ownerFilter={ownerFilter}
@@ -1998,14 +1895,6 @@ export function Dashboard() {
       totalCount={tableItems.length}
     />
   )
-
-  if (loading) {
-    return (
-      <div className="flex min-h-[400px] items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-blue-500"></div>
-      </div>
-    )
-  }
 
   if (error) {
     return (

--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -1105,6 +1105,8 @@ export function Dashboard() {
         let isLikedSongs = false
         let cachedData: PlaylistExportData | PlaylistExportDataV2 | undefined = undefined
         let useDifferentialMatching = false
+        let upToDate = false
+        let existingNavidromeId: string | undefined = undefined
 
         if ("isLikedSongs" in item && item.isLikedSongs) {
           const savedTracks = await spotifyClient.getAllSavedTracks(signal)
@@ -1127,10 +1129,30 @@ export function Dashboard() {
 
           // Check for cached export data
           cachedData = loadPlaylistExportData(item.id)
-          const upToDate = cachedData
+          existingNavidromeId = cachedData?.navidromePlaylistId
+
+          // If localStorage has no record, query Navidrome server for a linked playlist
+          if (!existingNavidromeId && !forceExportPlaylists) {
+            const serverPlaylist = await navidromeClient.getPlaylistByComment(item.id)
+            if (serverPlaylist) {
+              existingNavidromeId = serverPlaylist.id
+              cachedData = {
+                spotifyPlaylistId: item.id,
+                spotifySnapshotId: itemSnapshotId,
+                playlistName: item.name,
+                navidromePlaylistId: serverPlaylist.id,
+                exportedAt: new Date().toISOString(),
+                trackCount: 0,
+                tracks: {},
+                statistics: { total: 0, matched: 0, unmatched: 0, ambiguous: 0 },
+              }
+            }
+          }
+
+          upToDate = cachedData
             ? isPlaylistUpToDate(cachedData, itemSnapshotId)
             : false
-          const hasNavidromePlaylist = !!cachedData?.navidromePlaylistId
+          const hasNavidromePlaylist = !!existingNavidromeId
           useDifferentialMatching = !forceExportPlaylists && hasNavidromePlaylist
         }
 
@@ -1383,7 +1405,17 @@ export function Dashboard() {
           }
         }
 
-        if (isLikedSongs) {
+        // Skip unchanged playlists entirely (no tracks added/removed)
+        if (upToDate && existingNavidromeId && !forceExportPlaylists && !isLikedSongs) {
+          exportResultData = {
+            statistics: {
+              total: tracks.length,
+              starred: tracks.length,
+              skipped: 0,
+              failed: 0,
+            },
+          }
+        } else if (isLikedSongs) {
           const result = await favoritesExporter.exportFavorites(matches, {
             skipUnmatched: false,
             signal,
@@ -1627,6 +1659,19 @@ export function Dashboard() {
             setTrackExportCache((prev) =>
               new Map(prev).set(item.id, updatedCache),
             )
+
+            // Persist the link to the Navidrome playlist comment for cross-browser identity
+            try {
+              await navidromeClient.updatePlaylistComment(result.playlistId, {
+                spotifyPlaylistId: item.id,
+                navidromePlaylistId: result.playlistId,
+                spotifySnapshotId: itemSnapshotId,
+                exportedAt: updatedCache.exportedAt,
+                trackCount: tracks.length,
+              }, signal)
+            } catch (e) {
+              console.warn('Failed to update playlist comment:', e)
+            }
           }
         }
 

--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -1136,13 +1136,14 @@ export function Dashboard() {
             const serverPlaylist = await navidromeClient.getPlaylistByComment(item.id)
             if (serverPlaylist) {
               existingNavidromeId = serverPlaylist.id
+              const serverMetadata = parseExportMetadata(serverPlaylist.comment)
               cachedData = {
                 spotifyPlaylistId: item.id,
-                spotifySnapshotId: itemSnapshotId,
+                spotifySnapshotId: serverMetadata?.spotifySnapshotId ?? '',
                 playlistName: item.name,
                 navidromePlaylistId: serverPlaylist.id,
-                exportedAt: new Date().toISOString(),
-                trackCount: 0,
+                exportedAt: serverMetadata?.exportedAt ?? new Date().toISOString(),
+                trackCount: serverMetadata?.trackCount ?? 0,
                 tracks: {},
                 statistics: { total: 0, matched: 0, unmatched: 0, ambiguous: 0 },
               }

--- a/components/LoadingScreen.tsx
+++ b/components/LoadingScreen.tsx
@@ -1,0 +1,10 @@
+export function LoadingScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-black">
+      <div className="flex flex-col items-center gap-4">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-green-500 border-t-transparent" />
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">Loading...</p>
+      </div>
+    </div>
+  )
+}

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -3,8 +3,10 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { AuthContextType, SpotifyAuthState, NavidromeAuthState, SPOTIFY_STORAGE_KEY, NAVIDROME_STORAGE_KEY, SKIP_SPOTIFY_STORAGE_KEY } from '@/types/auth-context';
 import { SpotifyToken, SpotifyUser } from '@/types/spotify-auth';
-import { NavidromeCredentials } from '@/types/navidrome';
+import { SpotifyPlaylist } from '@/types/spotify';
+import { NavidromePlaylist, NavidromeCredentials } from '@/types/navidrome';
 import { NavidromeApiClient } from '@/lib/navidrome/client';
+import { spotifyClient } from '@/lib/spotify/client';
 import { getJSON, setJSON } from '@/lib/storage';
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -28,6 +30,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     getJSON<boolean>(SKIP_SPOTIFY_STORAGE_KEY, false),
   );
 
+  const [playlists, setPlaylists] = useState<SpotifyPlaylist[]>([]);
+  const [navidromePlaylists, setNavidromePlaylists] = useState<NavidromePlaylist[]>([]);
+  const [likedSongsCount, setLikedSongsCount] = useState<number>(0);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
   const testNavidromeConnection = useCallback(async (credentials: NavidromeCredentials): Promise<boolean> => {
     if (!credentials) {
       setNavidrome((prev) => ({
@@ -45,7 +53,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const storedAuth = localStorage.getItem(NAVIDROME_STORAGE_KEY);
       let storedToken = '';
       let storedClientId = '';
-      
+
       if (storedAuth) {
         const parsed = JSON.parse(storedAuth);
         storedToken = parsed.token ?? '';
@@ -59,11 +67,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         storedToken || undefined,
         storedClientId || undefined
       );
-      
+
       await client.ping();
       const token = client.getToken();
       const clientId = client.getClientId();
-      
+
       if (token && clientId) {
         localStorage.setItem(NAVIDROME_STORAGE_KEY, JSON.stringify({
           url: credentials.url,
@@ -72,7 +80,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           token,
           clientId,
         }));
-        
+
         setNavidrome((prev) => ({
           ...prev,
           isConnected: true,
@@ -139,26 +147,109 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  const fetchInitialData = useCallback(async (spotifyState: SpotifyAuthState, navidromeState: NavidromeAuthState) => {
+    const hasSpotify = spotifyState.isAuthenticated && !!spotifyState.token;
+
+    if (!hasSpotify) {
+      setPlaylists([]);
+      setLikedSongsCount(0);
+      setFetchError(null);
+      return;
+    }
+
+    setFetchError(null);
+
+    try {
+      spotifyClient.setToken(spotifyState.token!);
+      const fetchedPlaylists = await spotifyClient.getAllPlaylists();
+      setPlaylists(fetchedPlaylists);
+
+      try {
+        const count = await spotifyClient.getSavedTracksCount();
+        setLikedSongsCount(count);
+      } catch {
+        setLikedSongsCount(0);
+      }
+
+      if (
+        navidromeState.isConnected &&
+        navidromeState.credentials &&
+        navidromeState.token &&
+        navidromeState.clientId
+      ) {
+        const navidromeClient = new NavidromeApiClient(
+          navidromeState.credentials.url,
+          navidromeState.credentials.username,
+          navidromeState.credentials.password,
+          navidromeState.token,
+          navidromeState.clientId,
+        );
+        try {
+          const navPlaylists = await navidromeClient.getPlaylists();
+          setNavidromePlaylists(navPlaylists);
+        } catch (navErr) {
+          console.warn('Failed to fetch Navidrome playlists:', navErr);
+        }
+      }
+    } catch (err) {
+      setFetchError(err instanceof Error ? err.message : 'Failed to fetch playlists');
+    }
+  }, []);
+
+  const refreshData = useCallback(async () => {
+    if (!spotify.isAuthenticated || !spotify.token) return;
+    setRefreshing(true);
+    try {
+      await fetchInitialData(spotify, navidrome);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [spotify, navidrome, fetchInitialData]);
+
   const loadStoredAuth = useCallback(async () => {
+    let resolvedSpotify: SpotifyAuthState = {
+      isAuthenticated: false,
+      user: null,
+      token: null,
+    };
+    let resolvedNavidrome: NavidromeAuthState = {
+      isConnected: false,
+      credentials: null,
+      serverVersion: null,
+      error: null,
+      token: null,
+      clientId: null,
+    };
+
     try {
       const storedSpotify = localStorage.getItem(SPOTIFY_STORAGE_KEY);
       if (storedSpotify) {
         const parsed = JSON.parse(storedSpotify) as { token: SpotifyToken; user: SpotifyUser };
         if (parsed.token) {
           const isExpired = parsed.token.expiresAt <= Date.now();
-          
+
           if (isExpired) {
             const refreshed = await refreshSpotifyTokenFromStorage(parsed.token, parsed.user);
             if (refreshed) {
-              return;
+              resolvedSpotify = {
+                isAuthenticated: true,
+                token: JSON.parse(localStorage.getItem(SPOTIFY_STORAGE_KEY)!).token,
+                user: parsed.user,
+              };
+            } else {
+              localStorage.removeItem(SPOTIFY_STORAGE_KEY);
             }
-            localStorage.removeItem(SPOTIFY_STORAGE_KEY);
           } else {
             setSpotify({
               isAuthenticated: true,
               token: parsed.token,
               user: parsed.user,
             });
+            resolvedSpotify = {
+              isAuthenticated: true,
+              token: parsed.token,
+              user: parsed.user,
+            };
           }
         } else {
           localStorage.removeItem(SPOTIFY_STORAGE_KEY);
@@ -168,24 +259,33 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const storedNavidrome = localStorage.getItem(NAVIDROME_STORAGE_KEY);
       if (storedNavidrome) {
         const parsed = JSON.parse(storedNavidrome);
+        const navCreds = { url: parsed.url, username: parsed.username, password: parsed.password };
         setNavidrome((prev) => ({
           ...prev,
-          credentials: { url: parsed.url, username: parsed.username, password: parsed.password },
+          credentials: navCreds,
           token: parsed.token ?? null,
           clientId: parsed.clientId ?? '',
         }));
-        await testNavidromeConnection({ url: parsed.url, username: parsed.username, password: parsed.password });
+        resolvedNavidrome = {
+          isConnected: false,
+          credentials: navCreds,
+          serverVersion: null,
+          error: null,
+          token: parsed.token ?? null,
+          clientId: parsed.clientId ?? '',
+        };
+        await testNavidromeConnection(navCreds);
       }
 
       if (!storedSpotify) {
         const response = await fetch('/api/auth/session');
         const data = await response.json();
-        
+
         if (data.authenticated && data.token) {
           const response2 = await fetch('https://api.spotify.com/v1/me', {
             headers: { Authorization: `Bearer ${data.token.accessToken}` },
           });
-          
+
           if (response2.ok) {
             const user = await response2.json();
             const authData = { token: data.token, user };
@@ -195,15 +295,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               token: data.token,
               user,
             });
+            resolvedSpotify = {
+              isAuthenticated: true,
+              token: data.token,
+              user,
+            };
           }
         }
       }
     } catch (error) {
       console.error('Error loading stored auth:', error);
-    } finally {
-      setIsLoading(false);
     }
-  }, [testNavidromeConnection, refreshSpotifyTokenFromStorage]);
+
+    await fetchInitialData(resolvedSpotify, resolvedNavidrome);
+
+    setIsLoading(false);
+  }, [testNavidromeConnection, refreshSpotifyTokenFromStorage, fetchInitialData]);
 
   useEffect(() => {
     loadStoredAuth();
@@ -232,6 +339,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           user: null,
           token: null,
         });
+        setPlaylists([]);
+        setLikedSongsCount(0);
+        setNavidromePlaylists([]);
+        setFetchError(null);
       }
     } catch (error) {
       console.error('Error logging out from Spotify:', error);
@@ -241,6 +352,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         user: null,
         token: null,
       });
+      setPlaylists([]);
+      setLikedSongsCount(0);
+      setNavidromePlaylists([]);
+      setFetchError(null);
     }
   }, []);
 
@@ -248,7 +363,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const stored = localStorage.getItem(SPOTIFY_STORAGE_KEY);
       if (!stored) return false;
-      
+
       const parsed = JSON.parse(stored) as { token: SpotifyToken };
       if (!parsed.token?.refreshToken) return false;
 
@@ -285,9 +400,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         credentials.username,
         credentials.password
       );
-      
+
       const loginResult = await client.login(credentials.username, credentials.password);
-      
+
       if (!loginResult.success) {
         setNavidrome((prev) => ({
           ...prev,
@@ -301,7 +416,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       const token = client.getToken();
       const clientId = client.getClientId();
-      
+
       localStorage.setItem(NAVIDROME_STORAGE_KEY, JSON.stringify({
         url: credentials.url,
         username: credentials.username,
@@ -310,14 +425,31 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         clientId,
       }));
 
-      setNavidrome((prev) => ({
-        ...prev,
+      const nextNavidrome: NavidromeAuthState = {
         isConnected: true,
         serverVersion: 'Navidrome (native API)',
         error: null,
         token,
         clientId,
-      }));
+        credentials,
+      };
+      setNavidrome(nextNavidrome);
+
+      if (spotify.isAuthenticated && spotify.token) {
+        try {
+          const navidromeClient = new NavidromeApiClient(
+            credentials.url,
+            credentials.username,
+            credentials.password,
+            token,
+            clientId,
+          );
+          const navPlaylists = await navidromeClient.getPlaylists();
+          setNavidromePlaylists(navPlaylists);
+        } catch (navErr) {
+          console.warn('Failed to fetch Navidrome playlists:', navErr);
+        }
+      }
 
       return true;
     } catch (error) {
@@ -331,7 +463,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }));
       return false;
     }
-  }, []);
+  }, [spotify.isAuthenticated, spotify.token]);
 
   const clearNavidromeCredentials = useCallback(() => {
     localStorage.removeItem(NAVIDROME_STORAGE_KEY);
@@ -343,6 +475,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       token: null,
       clientId: null,
     });
+    setNavidromePlaylists([]);
   }, []);
 
   const setSkipSpotify = useCallback((skip: boolean) => {
@@ -366,6 +499,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     isLoading,
     skipSpotify,
     setSkipSpotify,
+    playlists,
+    navidromePlaylists,
+    likedSongsCount,
+    fetchError,
+    refreshing,
+    refreshData,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/lib/export/playlist-exporter.ts
+++ b/lib/export/playlist-exporter.ts
@@ -221,7 +221,8 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
           checkAbort();
 
           const existingTracks = await this.navidromeClient.getPlaylist(options.existingPlaylistId, signal);
-          const existingSongIds = existingTracks.tracks.map(t => t.id);
+          const existingSongIds = existingTracks.tracks.map(t => t.mediaFileId || t.id);
+          const existingIdSet = new Set(existingSongIds);
 
           if (arraysEqual(existingSongIds, songIds)) {
             exported = songIds.length;
@@ -229,15 +230,41 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
             break;
           }
 
-          const replaceResult = await this.navidromeClient.replacePlaylistSongs(options.existingPlaylistId, songIds, signal);
-          if (!replaceResult.success) {
-            errors.push({
-              trackName: 'N/A',
-              artistName: 'N/A',
-              reason: `Failed to replace tracks: ${replaceResult.error || 'Unknown error'}`,
-            });
-            break;
+          // Only add songs that aren't already in the playlist
+          const newSongIds = songIds.filter(id => !existingIdSet.has(id));
+          const removedEntryIndices = existingTracks.tracks
+            .map((t, i) => ({ mediaFileId: t.mediaFileId || t.id, index: i }))
+            .filter(({ mediaFileId }) => !songIds.includes(mediaFileId))
+            .map(({ index }) => index);
+
+          if (newSongIds.length > 0) {
+            const addResult = await this.navidromeClient.updatePlaylist(
+              options.existingPlaylistId, newSongIds, undefined, signal
+            );
+            if (!addResult.success) {
+              errors.push({
+                trackName: 'N/A',
+                artistName: 'N/A',
+                reason: `Failed to add new tracks: ${addResult.error || 'Unknown error'}`,
+              });
+              break;
+            }
           }
+
+          if (removedEntryIndices.length > 0) {
+            const removeResult = await this.navidromeClient.updatePlaylist(
+              options.existingPlaylistId, [], removedEntryIndices, signal
+            );
+            if (!removeResult.success) {
+              errors.push({
+                trackName: 'N/A',
+                artistName: 'N/A',
+                reason: `Failed to remove stale tracks: ${removeResult.error || 'Unknown error'}`,
+              });
+              break;
+            }
+          }
+
           exported = songIds.length;
           playlistId = options.existingPlaylistId;
           break;

--- a/lib/export/playlist-exporter.ts
+++ b/lib/export/playlist-exporter.ts
@@ -231,10 +231,12 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
           }
 
           // Only add songs that aren't already in the playlist
+          playlistId = options.existingPlaylistId;
           const newSongIds = songIds.filter(id => !existingIdSet.has(id));
+          const songIdSet = new Set(songIds);
           const removedEntryIndices = existingTracks.tracks
             .map((t, i) => ({ mediaFileId: t.mediaFileId || t.id, index: i }))
-            .filter(({ mediaFileId }) => !songIds.includes(mediaFileId))
+            .filter(({ mediaFileId }) => !songIdSet.has(mediaFileId))
             .map(({ index }) => index);
 
           if (newSongIds.length > 0) {
@@ -266,7 +268,6 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
           }
 
           exported = songIds.length;
-          playlistId = options.existingPlaylistId;
           break;
         }
       }

--- a/lib/matching/fuzzy.test.ts
+++ b/lib/matching/fuzzy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateTrackSimilarity, findBestMatch, normalizeTitle, normalizeArtistName } from '@/lib/matching/fuzzy';
+import { calculateTrackSimilarity, findBestMatch, normalizeTitle, normalizeArtistName, calculateBestArtistSimilarity, calculateAlbumSimilarity, normalizeString, hasVersionMismatch, extractVersionMarkers } from '@/lib/matching/fuzzy';
 import { SpotifyTrack } from '@/types/spotify';
 import { NavidromeSong } from '@/types/navidrome';
 
@@ -149,5 +149,234 @@ describe('normalizeArtistName', () => {
   it('normalizes collaboration indicators', () => {
     const name = normalizeArtistName('Artist Ft. Guest');
     expect(name).not.toContain('ft.');
+  });
+});
+
+describe('calculateBestArtistSimilarity', () => {
+  it('returns 1.0 when any individual artist matches exactly', () => {
+    const score = calculateBestArtistSimilarity(['Kendrick Lamar', 'SZA'], 'Kendrick Lamar');
+    expect(score).toBe(1.0);
+  });
+
+  it('scores higher than joined-string comparison for multi-artist tracks', () => {
+    const bestScore = calculateBestArtistSimilarity(['Kendrick Lamar', 'SZA'], 'Kendrick Lamar');
+    const joinedScore = calculateBestArtistSimilarity(['Kendrick Lamar SZA'], 'Kendrick Lamar');
+    expect(bestScore).toBeGreaterThan(joinedScore);
+  });
+
+  it('returns 0 when no artists overlap', () => {
+    const score = calculateBestArtistSimilarity(['Drake', 'Future'], 'Kendrick Lamar');
+    expect(score).toBeLessThan(0.5);
+  });
+});
+
+describe('per-artist matching in calculateTrackSimilarity', () => {
+  it('matches multi-artist Spotify track against single-artist Navidrome song', () => {
+    const multiArtistTrack: SpotifyTrack = {
+      id: 'sp2',
+      name: 'All The Stars',
+      uri: 'spotify:track:sp2',
+      artists: [{ id: 'a1', name: 'Kendrick Lamar' }, { id: 'a2', name: 'SZA' }],
+      album: { id: 'al1', name: 'Black Panther' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const navidromeSong: NavidromeSong = {
+      id: 'nd1',
+      title: 'All The Stars',
+      artist: 'Kendrick Lamar',
+      album: 'Black Panther',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(multiArtistTrack, navidromeSong);
+    expect(score).toBeGreaterThan(0.9);
+  });
+});
+
+describe('album similarity cap removed', () => {
+  it('returns raw token ratio without 0.8 multiplier', () => {
+    const score = calculateAlbumSimilarity('Same Album', 'Same Album');
+    expect(score).toBe(1.0);
+  });
+
+  it('returns proportional ratio for partial matches', () => {
+    const score = calculateAlbumSimilarity('Greatest Hits Vol 1', 'Greatest Hits');
+    expect(score).toBeGreaterThan(0.5);
+    expect(score).toBeLessThanOrEqual(1.0);
+  });
+});
+
+describe('article prefix stripping in normalizeString', () => {
+  it('strips leading "the"', () => {
+    expect(normalizeString('The Weeknd')).toBe('weeknd');
+  });
+
+  it('strips leading "a"', () => {
+    expect(normalizeString('A Tribe Called Quest')).toBe('tribe called quest');
+  });
+
+  it('strips leading "an"', () => {
+    expect(normalizeString('An Animal')).toBe('animal');
+  });
+
+  it('does not strip articles in the middle of a string', () => {
+    expect(normalizeString('Getting the Thing')).toBe('getting the thing');
+  });
+
+  it('does not strip articles at the end of a string', () => {
+    expect(normalizeString('Meet The')).toBe('meet the');
+  });
+});
+
+describe('artist gate', () => {
+  it('rejects wrong-artist match with same title', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp1',
+      name: 'Stay Another Night',
+      uri: 'spotify:track:sp1',
+      artists: [{ id: 'a1', name: 'Chris Ayer' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const wrongCandidate: NavidromeSong = {
+      id: 'nd1',
+      title: 'Stay Another Night',
+      artist: 'Cheat Codes',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, wrongCandidate);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('still matches correct artist with same title', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp1',
+      name: 'Stay Another Night',
+      uri: 'spotify:track:sp1',
+      artists: [{ id: 'a1', name: 'Chris Ayer' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const correctCandidate: NavidromeSong = {
+      id: 'nd1',
+      title: 'Stay Another Night',
+      artist: 'Chris Ayer',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, correctCandidate);
+    expect(score).toBeGreaterThan(0.8);
+  });
+});
+
+describe('version mismatch penalty', () => {
+  it('rejects remix matching original', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp2',
+      name: 'Love Me Like That',
+      uri: 'spotify:track:sp2',
+      artists: [{ id: 'a1', name: 'State of Sound' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const remixCandidate: NavidromeSong = {
+      id: 'nd2',
+      title: 'Love Me Like That (Landis Remix)',
+      artist: 'State of Sound',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, remixCandidate);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('rejects acoustic matching original', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp3',
+      name: 'Some Song',
+      uri: 'spotify:track:sp3',
+      artists: [{ id: 'a1', name: 'Some Artist' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const acousticCandidate: NavidromeSong = {
+      id: 'nd3',
+      title: 'Some Song (Acoustic)',
+      artist: 'Some Artist',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, acousticCandidate);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('rejects live matching original', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp4',
+      name: 'Some Song',
+      uri: 'spotify:track:sp4',
+      artists: [{ id: 'a1', name: 'Some Artist' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const liveCandidate: NavidromeSong = {
+      id: 'nd4',
+      title: 'Some Song (Live)',
+      artist: 'Some Artist',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, liveCandidate);
+    expect(score).toBeLessThan(0.8);
+  });
+
+  it('still matches when both have the same version marker', () => {
+    const spotifyTrack: SpotifyTrack = {
+      id: 'sp5',
+      name: 'Some Song (Remix)',
+      uri: 'spotify:track:sp5',
+      artists: [{ id: 'a1', name: 'Some Artist' }],
+      album: { id: 'al1', name: 'Some Album' },
+      duration_ms: 200000,
+      external_ids: {},
+    };
+    const remixCandidate: NavidromeSong = {
+      id: 'nd5',
+      title: 'Some Song (Remix)',
+      artist: 'Some Artist',
+      album: 'Some Album',
+      duration: 200,
+    };
+    const score = calculateTrackSimilarity(spotifyTrack, remixCandidate);
+    expect(score).toBeGreaterThan(0.8);
+  });
+});
+
+describe('hasVersionMismatch', () => {
+  it('detects mismatch when one has remix and other does not', () => {
+    expect(hasVersionMismatch('Song', 'Song (Remix)')).toBe(true);
+    expect(hasVersionMismatch('Song (Remix)', 'Song')).toBe(true);
+  });
+
+  it('detects no mismatch when both lack version markers', () => {
+    expect(hasVersionMismatch('Song', 'Song')).toBe(false);
+  });
+
+  it('detects no mismatch when both have same version marker', () => {
+    expect(hasVersionMismatch('Song (Remix)', 'Song (Remix)')).toBe(false);
+  });
+
+  it('detects mismatch when versions differ (remix vs live)', () => {
+    expect(hasVersionMismatch('Song (Remix)', 'Song (Live)')).toBe(true);
+  });
+
+  it('does not false-positive on titles without version markers in parentheses', () => {
+    expect(hasVersionMismatch('Live Your Life', 'Live Your Life')).toBe(false);
   });
 });

--- a/lib/matching/fuzzy.ts
+++ b/lib/matching/fuzzy.ts
@@ -292,7 +292,17 @@ export function calculateTrackSimilarity(
   let baseSimilarity = availableWeight > 0 ? weightedSum / availableWeight : titleSimilarity;
 
   if (titleSimilarity === 1.0 && (artistSimilarity < 0 || artistSimilarity >= 0.6)) {
-    baseSimilarity = (artistSimilarity >= 0 ? artistSimilarity * 0.2 : 0) + titleSimilarity * 0.4 + durationSimilarity * 0.3 + (albumSimilarity >= 0 ? albumSimilarity * 0.1 : 0);
+    let overrideWeight = 0.4 + 0.3; // title + duration are always available
+    let overrideSum = titleSimilarity * 0.4 + durationSimilarity * 0.3;
+    if (artistSimilarity >= 0) {
+      overrideWeight += 0.2;
+      overrideSum += artistSimilarity * 0.2;
+    }
+    if (albumSimilarity >= 0) {
+      overrideWeight += 0.1;
+      overrideSum += albumSimilarity * 0.1;
+    }
+    baseSimilarity = overrideSum / overrideWeight;
   }
 
   if (durationSimilarity >= 0.9 && (artistSimilarity < 0 || artistSimilarity >= 0.6)) {

--- a/lib/matching/fuzzy.ts
+++ b/lib/matching/fuzzy.ts
@@ -25,7 +25,8 @@ export function normalizeString(str: string): string {
     .replace(/[\u0300-\u036f]/g, '')
     .replace(/[^\w\s]/g, '')
     .replace(/\s+/g, ' ')
-    .trim();
+    .trim()
+    .replace(/^(the|a|an)\s+/, '');
 }
 
 export function levenshteinDistance(a: string, b: string): number {
@@ -88,6 +89,19 @@ export function calculateArtistSimilarity(
   return 1.0 - distance / maxLength;
 }
 
+export function calculateBestArtistSimilarity(
+  spotifyArtists: string[],
+  navidromeArtist: string
+): number {
+  let best = 0;
+  for (const artist of spotifyArtists) {
+    const score = calculateArtistSimilarity(artist, navidromeArtist);
+    if (score > best) best = score;
+    if (best === 1.0) break;
+  }
+  return best;
+}
+
 const DURATION_THRESHOLD_MS = 3000;
 
 export function calculateDurationSimilarity(
@@ -109,27 +123,6 @@ export function calculateDurationSimilarity(
 const SOUNDTRACK_WORDS = [
   'original', 'sound', 'track', 'ost', ' soundtrack', 'score',
   'complete', 'vol', 'volume', ' disc ', 'disk'
-];
-
-const LIVE_INDICATORS = [
-  ' (live)',
-  '- live',
-  ' [live]',
-  ' live',
-  '(live)',
-  '-live',
-  '[live]',
-];
-
-const COLLABORATION_INDICATORS = [
-  'feat', 'feat.', 'ft', 'ft.',
-  'with', ' x ', ' X ',
-  ' and ', ' & ',
-  ' vs ', ' versus ',
-  ' presents ', ' presenting ',
-  ' pres. ', ' pres ',
-  ' prod ', ' produced by ',
-  'DJ '
 ];
 
 const TITLE_SUFFIX_PATTERN = /[\(\[].*?[\)\]]\s*$|[-–—~/].*$/;
@@ -160,18 +153,21 @@ export function normalizeTitle(title: string): string {
   // Remove parenthetical/bracket groups containing featured artists
   // e.g. "(feat. Kehlani & Lil Yachty)", "[ft. Someone]"
   normalized = normalized.replace(FEATURED_ARTIST_PATTERN, ' ');
-  for (const indicator of LIVE_INDICATORS) {
-    normalized = normalized.replace(new RegExp(indicator.replace(/[[\]()]/g, '\\$&'), 'gi'), ' ');
-  }
   normalized = normalizeString(normalized);
   return normalized.replace(/\s+/g, ' ').trim();
 }
 
+const COLLABORATION_INDICATORS_AMBIGUOUS = /\s+[xX]\s+|\s+&\s+|\s+and\s+/g;
+
 export function normalizeArtistName(artist: string): string {
   let normalized = artist.toLowerCase();
-  for (const indicator of COLLABORATION_INDICATORS) {
-    normalized = normalized.replace(new RegExp(indicator.replace(/[[\]()]/g, '\\$&'), 'gi'), ' ');
-  }
+  // Strip clear collaboration indicators and everything after them
+  // e.g. "Kendrick Lamar feat. SZA" → "kendrick lamar"
+  normalized = normalized.replace(/\s+(?:feat\.?|ft\.?|featuring|with|vs\.?|versus|presents?\.?|presenting|prod\.?|produced by)\s.*$/gi, '');
+  // Remove ambiguous collaboration indicators (keep surrounding text)
+  normalized = normalized.replace(COLLABORATION_INDICATORS_AMBIGUOUS, ' ');
+  // Remove "DJ " prefix
+  normalized = normalized.replace(/^dj\s+/gi, '');
   normalized = normalizeString(normalized);
   return normalized.replace(/\s+/g, ' ').trim();
 }
@@ -195,7 +191,7 @@ export function calculateAlbumSimilarity(
   );
 
   const similarity = matchingParts.length / Math.max(spotifyParts.length, navidromeParts.length);
-  return similarity * 0.8;
+  return similarity;
 }
 
 export function calculateTitleSimilarity(
@@ -216,6 +212,38 @@ export function calculateTitleSimilarity(
   return 1.0 - distance / maxLength;
 }
 
+const VERSION_KEYWORDS = /\b(?:remix|rmxx|acoustic|instrumental|radio\s*edit|extended|dub|vip|rework|bootleg|karaoke|demo|unplugged|stripped|live|mix|edit|cover)\b/gi;
+
+export function extractVersionMarkers(title: string): Set<string> {
+  const markers = new Set<string>();
+  const groups = title.match(/[\(\[][^\)\]]*[\)\]]/g) || [];
+  for (const group of groups) {
+    const matches = group.match(VERSION_KEYWORDS);
+    if (matches) matches.forEach(m => markers.add(m.toLowerCase()));
+  }
+  const dashParts = title.split(/[-–—]/);
+  if (dashParts.length > 1) {
+    for (let i = 1; i < dashParts.length; i++) {
+      const matches = dashParts[i].match(VERSION_KEYWORDS);
+      if (matches) matches.forEach(m => markers.add(m.toLowerCase()));
+    }
+  }
+  return markers;
+}
+
+export function hasVersionMismatch(spotifyTitle: string, navidromeTitle: string): boolean {
+  const spotifyMarkers = extractVersionMarkers(spotifyTitle);
+  const navidromeMarkers = extractVersionMarkers(navidromeTitle);
+
+  if (spotifyMarkers.size === 0 && navidromeMarkers.size === 0) return false;
+  if (spotifyMarkers.size === 0 || navidromeMarkers.size === 0) return true;
+
+  for (const m of spotifyMarkers) {
+    if (navidromeMarkers.has(m)) return false;
+  }
+  return true;
+}
+
 export function calculateTrackSimilarity(
   spotifyTrack: import('@/types/spotify').SpotifyTrack,
   navidromeSong: import('@/types/navidrome').NavidromeSong
@@ -224,8 +252,8 @@ export function calculateTrackSimilarity(
   const hasSpotifyAlbum = spotifyTrack.album && spotifyTrack.album.name && spotifyTrack.album.name.length > 0;
 
   const artistSimilarity = hasSpotifyArtist
-    ? calculateArtistSimilarity(
-        spotifyTrack.artists.map((a) => a.name).join(' '),
+    ? calculateBestArtistSimilarity(
+        spotifyTrack.artists.map((a) => a.name),
         navidromeSong.artist
       )
     : -1;
@@ -263,19 +291,26 @@ export function calculateTrackSimilarity(
 
   let baseSimilarity = availableWeight > 0 ? weightedSum / availableWeight : titleSimilarity;
 
-  if (titleSimilarity === 1.0 && (artistSimilarity < 0 || artistSimilarity >= 0.3)) {
-    return Math.max(
-      (artistSimilarity >= 0 ? artistSimilarity * 0.2 : 0) + titleSimilarity * 0.4 + durationSimilarity * 0.3 + (albumSimilarity >= 0 ? albumSimilarity * 0.1 : 0),
-      0.85
-    );
+  if (titleSimilarity === 1.0 && (artistSimilarity < 0 || artistSimilarity >= 0.6)) {
+    baseSimilarity = (artistSimilarity >= 0 ? artistSimilarity * 0.2 : 0) + titleSimilarity * 0.4 + durationSimilarity * 0.3 + (albumSimilarity >= 0 ? albumSimilarity * 0.1 : 0);
   }
 
-  if (durationSimilarity >= 0.9 && (artistSimilarity < 0 || artistSimilarity >= 0.3)) {
+  if (durationSimilarity >= 0.9 && (artistSimilarity < 0 || artistSimilarity >= 0.6)) {
     baseSimilarity = Math.min(baseSimilarity + 0.1, 0.95);
   }
 
-  if (albumSimilarity >= 0.8 && titleSimilarity >= 0.6 && (artistSimilarity < 0 || artistSimilarity >= 0.4)) {
+  if (albumSimilarity >= 0.8 && titleSimilarity >= 0.6 && (artistSimilarity < 0 || artistSimilarity >= 0.6)) {
     baseSimilarity = Math.min(baseSimilarity + 0.05, 0.95);
+  }
+
+  // Artist gate: reject candidates with significantly different artists
+  if (artistSimilarity >= 0 && artistSimilarity < 0.6) {
+    baseSimilarity = Math.min(baseSimilarity, 0.5);
+  }
+
+  // Version mismatch penalty: reject different versions (remix vs original, live vs original, etc.)
+  if (hasVersionMismatch(spotifyTrack.name, navidromeSong.title)) {
+    baseSimilarity = Math.min(baseSimilarity, 0.5);
   }
 
   return baseSimilarity;

--- a/lib/matching/orchestrator.ts
+++ b/lib/matching/orchestrator.ts
@@ -177,7 +177,7 @@ export async function matchTrack(
   }
 
   if (opts.enableStrict) {
-    const strictResult = await matchByStrict(client, spotifyTrack, nativeCandidates, signal);
+    const strictResult = await matchByStrict(client, spotifyTrack, undefined, signal);
     strategyResults.push({
       strategy: 'strict',
       matched: strictResult.status === 'matched',

--- a/lib/matching/orchestrator.ts
+++ b/lib/matching/orchestrator.ts
@@ -84,6 +84,19 @@ export async function matchTrack(
   let nativeCandidates: NavidromeNativeSong[] = [];
 
   nativeCandidates = await client.searchByTitle(trackTitle, opts.maxSearchResults, signal);
+
+  if (nativeCandidates.length > 50 && spotifyTrack.artists?.length > 0) {
+    const narrowed = await client.searchByTitleAndArtist(
+      trackTitle,
+      spotifyTrack.artists[0].name,
+      opts.maxSearchResults,
+      signal,
+    );
+    if (narrowed.length > 0) {
+      nativeCandidates = narrowed;
+    }
+  }
+
   candidates = nativeCandidates.map(convertNativeSongToNavidromeSong);
 
   const spotifyDurationSec = spotifyTrack.duration_ms / 1000;
@@ -164,7 +177,7 @@ export async function matchTrack(
   }
 
   if (opts.enableStrict) {
-    const strictResult = await matchByStrict(client, spotifyTrack);
+    const strictResult = await matchByStrict(client, spotifyTrack, nativeCandidates, signal);
     strategyResults.push({
       strategy: 'strict',
       matched: strictResult.status === 'matched',

--- a/lib/matching/strict-matcher.test.ts
+++ b/lib/matching/strict-matcher.test.ts
@@ -49,3 +49,86 @@ describe('filterStrictMatches', () => {
     expect(result).toHaveLength(0);
   });
 });
+
+describe('collaboration indicator handling', () => {
+  it('matches artist with feat. suffix to plain artist', () => {
+    const featSong: NavidromeNativeSong = {
+      id: 's4',
+      title: 'Test Song',
+      artist: 'Test Artist feat. Guest',
+      artistId: 'a4',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    const result = filterStrictMatches([featSong], 'test artist', 'test song');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s4');
+  });
+
+  it('matches Spotify artist with feat. to plain Navidrome artist', () => {
+    const plainSong: NavidromeNativeSong = {
+      id: 's5',
+      title: 'Test Song',
+      artist: 'Test Artist',
+      artistId: 'a5',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    // matchByStrict normalizes 'Test Artist feat. Guest' → 'test artist' before calling filterStrictMatches
+    const result = filterStrictMatches([plainSong], 'test artist', 'test song');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s5');
+  });
+});
+
+describe('featured artist in title', () => {
+  it('matches title with feat. annotation to plain title', () => {
+    const featTitleSong: NavidromeNativeSong = {
+      id: 's6',
+      title: 'Hit Song (feat. Someone)',
+      artist: 'Test Artist',
+      artistId: 'a6',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    const result = filterStrictMatches([featTitleSong], 'test artist', 'hit song');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s6');
+  });
+});
+
+describe('version mismatch detection', () => {
+  it('rejects version mismatch when normalized titles match', () => {
+    const liveSong: NavidromeNativeSong = {
+      id: 's7',
+      title: 'Test Song (Live)',
+      artist: 'Test Artist',
+      artistId: 'a7',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    // Both "Test Song Live" and "Test Song (Live)" normalize to "test song live"
+    // but only the Navidrome version has a version marker in parentheses
+    const result = filterStrictMatches([liveSong], 'test artist', 'test song live', 'Test Song Live');
+    expect(result).toHaveLength(0);
+  });
+
+  it('matches when both have same version marker', () => {
+    const remixSong: NavidromeNativeSong = {
+      id: 's8',
+      title: 'Test Song (Remix)',
+      artist: 'Test Artist',
+      artistId: 'a8',
+      album: 'Album',
+      albumId: 'al1',
+      duration: 200,
+    };
+    const result = filterStrictMatches([remixSong], 'test artist', 'test song remix', 'Test Song (Remix)');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s8');
+  });
+});

--- a/lib/matching/strict-matcher.ts
+++ b/lib/matching/strict-matcher.ts
@@ -4,26 +4,32 @@ import { NavidromeApiClient } from '@/lib/navidrome/client';
 import { NavidromeNativeSong } from '@/types/navidrome';
 import { convertNativeSongToNavidromeSong } from './orchestrator';
 import { trackKey as getTrackKey } from '@/lib/spotify/track-identity';
+import { normalizeTitle as normalizeTitleFuzzy, normalizeArtistName as normalizeArtistNameFuzzy, hasVersionMismatch } from './fuzzy';
 
 export function normalizeString(str: string): string {
   return str
     .toLowerCase()
     .replace(/[^a-z0-9\s]/g, '')
     .replace(/\s+/g, ' ')
-    .trim();
+    .trim()
+    .replace(/^(the|a|an)\s+/, '');
 }
 
 export function filterStrictMatches(
   songs: NavidromeNativeSong[],
   normalizedArtist: string | null,
-  normalizedTitle: string
+  normalizedTitle: string,
+  rawSpotifyTitle?: string
 ): NavidromeNativeSong[] {
   return songs.filter((song) => {
-    const songTitle = normalizeString(song.title);
+    const songTitle = normalizeTitleFuzzy(song.title);
     if (songTitle !== normalizedTitle) return false;
-    if (normalizedArtist === null) return true;
-    const songArtist = normalizeString(song.artist);
-    return songArtist === normalizedArtist;
+    if (normalizedArtist !== null) {
+      const songArtist = normalizeArtistNameFuzzy(song.artist);
+      if (songArtist !== normalizedArtist) return false;
+    }
+    if (rawSpotifyTitle && hasVersionMismatch(rawSpotifyTitle, song.title)) return false;
+    return true;
   });
 }
 
@@ -36,9 +42,9 @@ export async function matchByStrict(
   const tk = getTrackKey(spotifyTrack);
   const hasArtist = spotifyTrack.artists && spotifyTrack.artists.length > 0 && spotifyTrack.artists.some(a => a.name.trim().length > 0);
   const normalizedArtist = hasArtist
-    ? normalizeString(spotifyTrack.artists.map((a) => a.name).join(' '))
+    ? normalizeArtistNameFuzzy(spotifyTrack.artists.map((a) => a.name).join(' '))
     : null;
-  const normalizedTitle = normalizeString(spotifyTrack.name);
+  const normalizedTitle = normalizeTitleFuzzy(spotifyTrack.name);
 
   if (!normalizedTitle) {
     return {
@@ -52,7 +58,7 @@ export async function matchByStrict(
 
   try {
     const songs = candidates || await client.searchByTitle(spotifyTrack.name, 100, signal);
-    const matches = filterStrictMatches(songs, normalizedArtist, normalizedTitle);
+    const matches = filterStrictMatches(songs, normalizedArtist, normalizedTitle, spotifyTrack.name);
 
     if (matches.length === 0) {
       return {

--- a/lib/navidrome/client.ts
+++ b/lib/navidrome/client.ts
@@ -261,15 +261,22 @@ export class NavidromeApiClient {
         _order: 'ASC',
       };
 
-      const response = await this._makeNativeRequest<{
-        items: NavidromePlaylist[];
-      }>('/api/playlist', params, signal);
+      const response = await this._makeNativeRequest<NavidromePlaylist[] | { items: NavidromePlaylist[] }>('/api/playlist', params, signal);
 
-      if (response.items && response.items.length > 0) {
-        allPlaylists.push(...response.items.map(this._mapPlaylist));
+      let items: NavidromePlaylist[];
+      if (Array.isArray(response)) {
+        items = response;
+      } else if (response.items) {
+        items = response.items;
+      } else {
+        items = [];
       }
 
-      if (allPlaylists.length >= this._totalCount || !response.items || response.items.length === 0) {
+      if (items.length > 0) {
+        allPlaylists.push(...items.map(this._mapPlaylist));
+      }
+
+      if (allPlaylists.length >= this._totalCount || items.length === 0) {
         break;
       }
 
@@ -286,13 +293,20 @@ export class NavidromeApiClient {
     const playlistResponse = await this._makeNativeRequest<NavidromePlaylist>(`/api/playlist/${playlistId}`, {}, signal);
     const playlist = this._mapPlaylist(playlistResponse);
 
-    const tracksResponse = await this._makeNativeRequest<{
-      items: NavidromeNativeSong[];
-    }>(`/api/playlist/${playlistId}/tracks`, { _start: 0, _end: 1000 }, signal);
+    const tracksResponse = await this._makeNativeRequest<NavidromeNativeSong[] | { items: NavidromeNativeSong[] }>(`/api/playlist/${playlistId}/tracks`, { _start: 0, _end: 1000 }, signal);
+
+    let tracks: NavidromeNativeSong[];
+    if (Array.isArray(tracksResponse)) {
+      tracks = tracksResponse;
+    } else if (tracksResponse.items) {
+      tracks = tracksResponse.items;
+    } else {
+      tracks = [];
+    }
 
     return {
       playlist,
-      tracks: tracksResponse.items || [],
+      tracks,
     };
   }
 

--- a/lib/navidrome/client.ts
+++ b/lib/navidrome/client.ts
@@ -537,6 +537,22 @@ export class NavidromeApiClient {
     return songs;
   }
 
+  async searchByTitleAndArtist(title: string, artistName: string, limit?: number, signal?: AbortSignal): Promise<NavidromeNativeSong[]> {
+    const end = limit || 50;
+    const strippedTitle = stripTitleSuffix(title);
+
+    const artist = await this.getArtistByName(artistName);
+    if (!artist) return [];
+
+    let songs = await this.searchByQuery('', { title: strippedTitle, artistId: artist.id, _start: 0, _end: end }, signal);
+
+    if (songs.length === 0 && title !== strippedTitle) {
+      songs = await this.searchByQuery('', { title, artistId: artist.id, _start: 0, _end: end }, signal);
+    }
+
+    return songs;
+  }
+
   async getSongByTitle(title: string): Promise<NavidromeNativeSong | null> {
     try {
       const params: Record<string, string | number | undefined> = {

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -272,16 +272,30 @@ export class SpotifyClient {
       fetchOptions.cache = 'no-store';
     }
 
-    const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, fetchOptions);
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, fetchOptions);
 
-    if (response.status === 401) {
-      const refreshed = await this.refreshAccessToken();
-      if (refreshed) {
-        return this.fetch(endpoint, signal, options, bypassCache);
+      if (response.status === 401) {
+        const refreshed = await this.refreshAccessToken();
+        if (refreshed) {
+          return this.fetch(endpoint, signal, options, bypassCache);
+        }
       }
+
+      if (response.status >= 500 && response.status < 600) {
+        lastError = new Error(`Spotify API error: ${response.status}`);
+        if (attempt < 2) {
+          const delay = Math.pow(2, attempt) * 1000;
+          await new Promise(resolve => setTimeout(resolve, delay));
+          continue;
+        }
+      }
+
+      return response;
     }
 
-    return response;
+    throw lastError || new Error('Spotify API request failed');
   }
 
   clearToken(): void {

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -281,6 +281,7 @@ export class SpotifyClient {
         if (refreshed) {
           return this.fetch(endpoint, signal, options, bypassCache);
         }
+        throw new Error('Token expired and refresh failed');
       }
 
       if (response.status >= 500 && response.status < 600) {
@@ -290,6 +291,7 @@ export class SpotifyClient {
           await new Promise(resolve => setTimeout(resolve, delay));
           continue;
         }
+        throw lastError;
       }
 
       return response;

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -250,7 +250,7 @@ export class SpotifyClient {
       }
     }
 
-    const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, {
+    const fetchOptions: RequestInit = {
       ...options,
       signal,
       headers: {
@@ -258,7 +258,13 @@ export class SpotifyClient {
         'Content-Type': 'application/json',
         ...options.headers,
       },
-    });
+    };
+
+    if (bypassCache) {
+      fetchOptions.cache = 'no-store';
+    }
+
+    const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, fetchOptions);
 
     if (response.status === 401) {
       const refreshed = await this.refreshAccessToken();

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -201,37 +201,45 @@ export class SpotifyClient {
   async refreshAccessToken(): Promise<SpotifyToken | null> {
     if (!this.token?.refreshToken) return null;
 
-    try {
-      const response = await fetch('/api/auth/refresh', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refreshToken: this.token.refreshToken }),
-      });
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const response = await fetch('/api/auth/refresh', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refreshToken: this.token.refreshToken }),
+        });
 
-      if (!response.ok) return null;
+        if (!response.ok) {
+          if (response.status === 400) return null;
+          throw new Error(`Refresh failed: ${response.status}`);
+        }
 
-      const data = await response.json();
-      const newToken: SpotifyToken = {
-        accessToken: data.access_token,
-        refreshToken: this.token.refreshToken,
-        expiresAt: Date.now() + data.expires_in * 1000,
-        tokenType: data.token_type,
-        scope: data.scope,
-      };
+        const data = await response.json();
+        const newToken: SpotifyToken = {
+          accessToken: data.access_token,
+          refreshToken: this.token.refreshToken,
+          expiresAt: Date.now() + data.expires_in * 1000,
+          tokenType: data.token_type,
+          scope: data.scope,
+        };
 
-      this.setToken(newToken);
-      
-      const stored = localStorage.getItem(SPOTIFY_STORAGE_KEY);
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        parsed.token = newToken;
-        localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(parsed));
+        this.setToken(newToken);
+        
+        const stored = localStorage.getItem(SPOTIFY_STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          parsed.token = newToken;
+          localStorage.setItem(SPOTIFY_STORAGE_KEY, JSON.stringify(parsed));
+        }
+        
+        return newToken;
+      } catch {
+        if (attempt < 2) {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
       }
-      
-      return newToken;
-    } catch {
-      return null;
     }
+    return null;
   }
 
   private async fetch(endpoint: string, signal?: AbortSignal, options: RequestInit = {}, bypassCache: boolean = false): Promise<Response> {

--- a/types/auth-context.ts
+++ b/types/auth-context.ts
@@ -1,5 +1,6 @@
 import { SpotifyToken, SpotifyUser } from './spotify-auth';
-import { NavidromeCredentials } from './navidrome';
+import { NavidromeCredentials, NavidromePlaylist } from './navidrome';
+import { SpotifyPlaylist } from './spotify';
 
 export interface SpotifyAuthState {
   isAuthenticated: boolean;
@@ -28,6 +29,12 @@ export interface AuthContextType {
   isLoading: boolean;
   skipSpotify: boolean;
   setSkipSpotify: (skip: boolean) => void;
+  playlists: SpotifyPlaylist[];
+  navidromePlaylists: NavidromePlaylist[];
+  likedSongsCount: number;
+  fetchError: string | null;
+  refreshing: boolean;
+  refreshData: () => Promise<void>;
 }
 
 export const SPOTIFY_STORAGE_KEY = 'navispot_spotify_auth';

--- a/types/navidrome.ts
+++ b/types/navidrome.ts
@@ -21,6 +21,7 @@ export interface NavidromeApiConfig {
 
 export interface NavidromeNativeSong {
   id: string;
+  mediaFileId?: string;
   title: string;
   artist: string;
   artistId: string;


### PR DESCRIPTION
## Summary
- clear the persistent Spotify token cookie during logout
- remove malformed Spotify session cookies during session validation

## Validation
- Automated checks could not run because npm is unavailable in the environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent full-screen loading experience during sign-in.
  * Improved playlist refresh and synchronization with clearer updates and fewer unnecessary exports.
  * Added incremental playlist updates, preserving existing tracks while adding or removing only changes.

* **Bug Fixes**
  * Invalid or deleted Spotify sessions now clear stale authentication data.
  * Improved song matching for artists, versions, featured tracks, and titles.
  * Increased resilience when Spotify or Navidrome requests temporarily fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->