### PR TITLE
fix(spotify): use /tracks endpoint for playlist items fetch (#21)

### DIFF
--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -36,7 +36,7 @@ export class SpotifyClient {
   async getPlaylistTracks(playlistId: string, limit: number = 100, offset: number = 0, signal?: AbortSignal): Promise<SpotifyTracksResponse> {
     await spotifyRateLimiter.acquire();
     const params = new URLSearchParams({ limit: limit.toString(), offset: offset.toString() });
-    const response = await this.fetch(`/playlists/${playlistId}/items?${params.toString()}`, signal);
+    const response = await this.fetch(`/playlists/${playlistId}/tracks?${params.toString()}`, signal);
     return response.json();
   }
 
@@ -128,7 +128,7 @@ export class SpotifyClient {
 
     // Fetch first page to get the total and the first page's dates
     const firstResponse = await this.fetch(
-      `/playlists/${playlistId}/items?fields=${fields}&limit=${limit}&offset=0`,
+      `/playlists/${playlistId}/tracks?fields=${fields}&limit=${limit}&offset=0`,
       signal,
     );
     const firstData = await firstResponse.json();
@@ -152,7 +152,7 @@ export class SpotifyClient {
     if (lastOffset <= 0) return earliest;
     await backgroundRateLimiter.acquire();
     const lastResponse = await this.fetch(
-      `/playlists/${playlistId}/items?fields=${fields}&limit=${limit}&offset=${lastOffset}`,
+      `/playlists/${playlistId}/tracks?fields=${fields}&limit=${limit}&offset=${lastOffset}`,
       signal,
     );
     const lastData = await lastResponse.json();


### PR DESCRIPTION
## Problem

Issue #21 reports playlists stuck at **pending, 0%, no songs displayed**, with export showing **"Export was successful"** while nothing actually happens.

## Root cause

The authenticated `SpotifyClient` was calling `GET /playlists/{id}/items`, which Spotify returns **404** for the playlist resource. The valid endpoint per the Spotify Web API is `GET /playlists/{id}/tracks` (deprecated alias, still functional) or the new `GET /playlists/{id}/items` (which uses a different response shape: `items[].item` instead of `items[].track`).

This caused:
1. **0 songs, pending status** — `getAllPlaylistTracks` returned `[]`, leaving `playlistTracksCache` empty.
2. **Export "success" with nothing happening** — `matches.length === 0` triggers the early-return at `lib/export/playlist-exporter.ts:226` which returns `{ success: true, exported: 0, skipped: matches.length }`. The toast fires, but no Navidrome call was ever made.

## Fix

Changed all 3 occurrences in `lib/spotify/client.ts` from `/items` to `/tracks`:
- Line 39: `getPlaylistTracks`
- Line 131: `getPlaylistCreatedDate` first-page fetch
- Line 155: `getPlaylistCreatedDate` last-page fetch

This matches what `lib/spotify/public-client.ts:160` already does correctly (which is why public URL imports work but authenticated user playlists don't — the user's report confirms this).

## Verification

- `tsc --noEmit` clean
- `eslint lib/spotify/client.ts` clean
- Grep confirms no other `/playlists/${...}/items` patterns remain in the codebase

Fixes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist track retrieval by using the correct Spotify playlist tracks endpoint.
  * Improved playlist creation-date detection, including accurate handling of the oldest tracks in paginated playlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->