### PR TITLE
test(spotify): regression tests for playlist /tracks endpoint fix (#21)

### DIFF
--- a/lib/spotify/client-endpoint.test.ts
+++ b/lib/spotify/client-endpoint.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SpotifyClient } from '@/lib/spotify/client';
+import { SpotifyToken } from '@/types';
+
+const validToken: SpotifyToken = {
+  accessToken: 'test-access-token',
+  refreshToken: 'test-refresh-token',
+  expiresAt: Date.now() + 3600 * 1000,
+  tokenType: 'Bearer',
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('SpotifyClient playlist endpoint (regression for #21)', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: SpotifyClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    client = new SpotifyClient();
+    client.setToken(validToken);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('getPlaylistTracks calls /playlists/{id}/tracks (not /items)', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      items: [],
+      next: null,
+      total: 0,
+    }));
+
+    await client.getPlaylistTracks('playlist-123', 100, 0);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('/playlists/playlist-123/tracks');
+    expect(url).not.toContain('/items');
+  });
+
+  it('getAllPlaylistTracks paginates with /tracks across multiple pages', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({
+        items: [{ track: { id: 't1' } }],
+        next: 'next-url',
+        total: 150,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        items: [{ track: { id: 't2' } }],
+        next: null,
+        total: 150,
+      }));
+
+    const tracks = await client.getAllPlaylistTracks('playlist-456');
+
+    expect(tracks).toHaveLength(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    for (const call of fetchSpy.mock.calls) {
+      const url = call[0] as string;
+      expect(url).toContain('/playlists/playlist-456/tracks');
+      expect(url).not.toContain('/items');
+    }
+  });
+
+  it('getPlaylistCreatedDate uses /tracks for both first and last page', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({
+        items: [{ added_at: '2024-01-15T00:00:00Z' }],
+        total: 150,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        items: [{ added_at: '2020-06-01T00:00:00Z' }],
+        total: 150,
+      }));
+
+    await client.getPlaylistCreatedDate('playlist-789');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    for (const call of fetchSpy.mock.calls) {
+      const url = call[0] as string;
+      expect(url).toContain('/playlists/playlist-789/tracks');
+      expect(url).not.toContain('/items');
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds 3 Vitest regression tests in `lib/spotify/client-endpoint.test.ts` that lock in the endpoint fix from PR #22.

## Why

PR #22 fixed #21 by changing `GET /playlists/{id}/items` → `GET /playlists/{id}/tracks` in `lib/spotify/client.ts`. Without tests, the same bug could reappear via a typo, a refactor, or someone "upgrading" to the new `/items` endpoint without realizing its response shape differs (`items[].item` vs `items[].track`).

## Coverage

Each test stubs global `fetch` and asserts the URL passed to Spotify:

- `getPlaylistTracks` — single page
- `getAllPlaylistTracks` — multi-page pagination across 2 requests
- `getPlaylistCreatedDate` — both the first-page and last-page fetches

Every assertion checks `url.contains('/playlists/{id}/tracks')` and `!url.contains('/items')`.

## Verification

- `npx vitest run` → 54/54 tests pass (3 new + 51 existing)
- `npx tsc --noEmit` → clean
- `npx eslint lib/spotify/client-endpoint.test.ts` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playlist track retrieval to use the correct Spotify endpoint.
  * Improved reliability for paginated playlist track loading and playlist creation date retrieval.

* **Tests**
  * Added regression coverage for playlist endpoint requests and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->