### PR TITLE
fix(spotify): switch playlist tracks endpoint from deprecated /tracks to /items

### DIFF
--- a/lib/spotify/client-endpoint.test.ts
+++ b/lib/spotify/client-endpoint.test.ts
@@ -16,7 +16,7 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
-describe('SpotifyClient playlist endpoint (regression for #21)', () => {
+describe('SpotifyClient playlist endpoint uses non-deprecated /items', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
   let client: SpotifyClient;
 
@@ -31,7 +31,7 @@ describe('SpotifyClient playlist endpoint (regression for #21)', () => {
     vi.unstubAllGlobals();
   });
 
-  it('getPlaylistTracks calls /playlists/{id}/tracks (not /items)', async () => {
+  it('getPlaylistTracks calls /playlists/{id}/items (not deprecated /tracks)', async () => {
     fetchSpy.mockResolvedValue(jsonResponse({
       items: [],
       next: null,
@@ -42,19 +42,19 @@ describe('SpotifyClient playlist endpoint (regression for #21)', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const url = fetchSpy.mock.calls[0][0] as string;
-    expect(url).toContain('/playlists/playlist-123/tracks');
-    expect(url).not.toContain('/items');
+    expect(url).toContain('/playlists/playlist-123/items');
+    expect(url).not.toContain('/tracks');
   });
 
-  it('getAllPlaylistTracks paginates with /tracks across multiple pages', async () => {
+  it('getAllPlaylistTracks paginates with /items across multiple pages', async () => {
     fetchSpy
       .mockResolvedValueOnce(jsonResponse({
-        items: [{ track: { id: 't1' } }],
+        items: [{ item: { id: 't1' } }],
         next: 'next-url',
         total: 150,
       }))
       .mockResolvedValueOnce(jsonResponse({
-        items: [{ track: { id: 't2' } }],
+        items: [{ item: { id: 't2' } }],
         next: null,
         total: 150,
       }));
@@ -65,12 +65,12 @@ describe('SpotifyClient playlist endpoint (regression for #21)', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     for (const call of fetchSpy.mock.calls) {
       const url = call[0] as string;
-      expect(url).toContain('/playlists/playlist-456/tracks');
-      expect(url).not.toContain('/items');
+      expect(url).toContain('/playlists/playlist-456/items');
+      expect(url).not.toContain('/tracks');
     }
   });
 
-  it('getPlaylistCreatedDate uses /tracks for both first and last page', async () => {
+  it('getPlaylistCreatedDate uses /items for both first and last page', async () => {
     fetchSpy
       .mockResolvedValueOnce(jsonResponse({
         items: [{ added_at: '2024-01-15T00:00:00Z' }],
@@ -86,8 +86,8 @@ describe('SpotifyClient playlist endpoint (regression for #21)', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     for (const call of fetchSpy.mock.calls) {
       const url = call[0] as string;
-      expect(url).toContain('/playlists/playlist-789/tracks');
-      expect(url).not.toContain('/items');
+      expect(url).toContain('/playlists/playlist-789/items');
+      expect(url).not.toContain('/tracks');
     }
   });
 });

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -33,17 +33,24 @@ export class SpotifyClient {
     return response.json();
   }
 
-  async getPlaylistTracks(playlistId: string, limit: number = 100, offset: number = 0, signal?: AbortSignal): Promise<SpotifyTracksResponse> {
+  async getPlaylistTracks(playlistId: string, limit: number = 50, offset: number = 0, signal?: AbortSignal): Promise<SpotifyTracksResponse> {
     await spotifyRateLimiter.acquire();
     const params = new URLSearchParams({ limit: limit.toString(), offset: offset.toString() });
-    const response = await this.fetch(`/playlists/${playlistId}/tracks?${params.toString()}`, signal);
-    return response.json();
+    const response = await this.fetch(`/playlists/${playlistId}/items?${params.toString()}`, signal);
+    const data = await response.json();
+    if (data.items) {
+      data.items = data.items.map((i: Record<string, unknown>) => ({
+        ...i,
+        track: (i as Record<string, unknown>).item ?? i.track,
+      }));
+    }
+    return data;
   }
 
   async getAllPlaylistTracks(playlistId: string, signal?: AbortSignal): Promise<SpotifyPlaylistTrack[]> {
     const allTracks: SpotifyPlaylistTrack[] = [];
     let offset = 0;
-    const limit = 100;
+    const limit = 50;
 
     while (true) {
       const response = await this.getPlaylistTracks(playlistId, limit, offset, signal);
@@ -124,11 +131,11 @@ export class SpotifyClient {
   async getPlaylistCreatedDate(playlistId: string, signal?: AbortSignal): Promise<string | undefined> {
     await backgroundRateLimiter.acquire();
     const fields = 'items(added_at),total';
-    const limit = 100;
+    const limit = 50;
 
     // Fetch first page to get the total and the first page's dates
     const firstResponse = await this.fetch(
-      `/playlists/${playlistId}/tracks?fields=${fields}&limit=${limit}&offset=0`,
+      `/playlists/${playlistId}/items?fields=${fields}&limit=${limit}&offset=0`,
       signal,
     );
     const firstData = await firstResponse.json();
@@ -152,7 +159,7 @@ export class SpotifyClient {
     if (lastOffset <= 0) return earliest;
     await backgroundRateLimiter.acquire();
     const lastResponse = await this.fetch(
-      `/playlists/${playlistId}/tracks?fields=${fields}&limit=${limit}&offset=${lastOffset}`,
+      `/playlists/${playlistId}/items?fields=${fields}&limit=${limit}&offset=${lastOffset}`,
       signal,
     );
     const lastData = await lastResponse.json();

--- a/lib/spotify/public-client.ts
+++ b/lib/spotify/public-client.ts
@@ -134,6 +134,7 @@ interface PlaylistMeta {
 
 interface SpotifyTrackItem {
   track: SpotifyTrack | null;
+  item: SpotifyTrack | null;
   is_local?: boolean;
   added_at?: string;
 }
@@ -157,12 +158,13 @@ export async function getPublicPlaylist(
   const tracks: SpotifyTrack[] = [];
   let nullTrackCount = 0;
   let nextPath: string | null =
-    `/playlists/${playlistId}/tracks?fields=items(track(id,name,artists(id,name),album(id,name,release_date),duration_ms,external_ids,external_urls,uri,is_local),is_local,added_at),next,snapshot_id&limit=100`;
+    `/playlists/${playlistId}/items?fields=items(item(id,name,artists(id,name),album(id,name,release_date),duration_ms,external_ids,external_urls,uri,is_local),is_local,added_at),next,snapshot_id&limit=50`;
   while (nextPath) {
     const page: PlaylistTracksPage = await spotifyGet<PlaylistTracksPage>(token, nextPath);
     for (const item of page.items) {
-      if (item.track) {
-        const track = item.track;
+      const itemData = (item as Record<string, unknown>).item as SpotifyTrack | null;
+      const track = itemData ?? item.track;
+      if (track) {
         if (item.is_local) {
           track.is_local = true;
         }


### PR DESCRIPTION
## What
Switches all playlist track fetching from the deprecated `GET /playlists/{id}/tracks` endpoint to the replacement `GET /playlists/{id}/items` per [Spotify Web API docs](https://developer.spotify.com/documentation/web-api/reference/get-playlists-tracks).

## Changes
- **`lib/spotify/client.ts`** — 3 call sites switched from `/tracks` to `/items`, added `item → track` response normalizer for backwards compatibility, default limit 100→50
- **`lib/spotify/public-client.ts`** — Pagination endpoint and `fields` param updated (`track(...)` → `item(...)`), added `item` field extraction
- **`lib/spotify/client-endpoint.test.ts`** — Tests now assert the non-deprecated `/items` endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated playlist retrieval to use Spotify’s current playlist items endpoints.
  * Improved compatibility with playlist item responses while preserving track data handling.
  * Reduced playlist page sizes to improve reliable pagination.
  * Updated playlist date and public playlist retrieval to work with the revised response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->