### PR TITLE
fix(spotify): throw on non-2xx responses, harden error body, add debug log

### DIFF
--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import { SpotifyPlaylist, SpotifyTrack } from "@/types/spotify"
 import { NavidromePlaylist } from "@/types/navidrome"
 import { PlaylistTable } from "@/components/Dashboard/PlaylistTable"
 import { ExportLayoutManager } from "@/components/Dashboard/ExportLayoutManager"
+import { log } from "@/lib/support/debug-log"
 
 import { ConfirmationPopup } from "@/components/Dashboard/ConfirmationPopup"
 import { CancelConfirmationDialog } from "@/components/Dashboard/CancelConfirmationDialog"
@@ -1595,6 +1596,7 @@ export function Dashboard() {
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "Export failed"
+      log('export failed:', err)
 
       if (err instanceof DOMException && err.name === 'AbortError') {
         toast.showWarning("Export was cancelled")

--- a/lib/spotify/client-endpoint.test.ts
+++ b/lib/spotify/client-endpoint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { SpotifyClient } from '@/lib/spotify/client';
+import { SpotifyClient, SpotifyApiError } from '@/lib/spotify/client';
 import { SpotifyToken } from '@/types';
 
 const validToken: SpotifyToken = {
@@ -9,11 +9,15 @@ const validToken: SpotifyToken = {
   tokenType: 'Bearer',
 };
 
-function jsonResponse(body: unknown): Response {
+function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+function errorResponse(status: number, body: unknown = { error: { status, message: 'err' } }): Response {
+  return jsonResponse(body, status);
 }
 
 describe('SpotifyClient playlist endpoint uses non-deprecated /items', () => {
@@ -89,5 +93,186 @@ describe('SpotifyClient playlist endpoint uses non-deprecated /items', () => {
       expect(url).toContain('/playlists/playlist-789/items');
       expect(url).not.toContain('/tracks');
     }
+  });
+});
+
+describe('SpotifyClient playlist error handling (regression for issue #9)', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: SpotifyClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    client = new SpotifyClient();
+    client.setToken(validToken);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('getAllPlaylistTracks throws SpotifyApiError(403) with raw body intact', async () => {
+    const body = { error: { status: 403, message: 'Forbidden' } };
+    fetchSpy.mockResolvedValue(errorResponse(403, body));
+
+    await expect(client.getAllPlaylistTracks('forbidden-playlist'))
+      .rejects.toBeInstanceOf(SpotifyApiError);
+
+    await expect(client.getAllPlaylistTracks('forbidden-playlist'))
+      .rejects.toMatchObject({ status: 403, name: 'SpotifyApiError' });
+
+    await expect(client.getAllPlaylistTracks('forbidden-playlist'))
+      .rejects.toThrow(/Spotify API error 403/);
+  });
+
+  it('getAllPlaylistTracks throws SpotifyApiError(404) when playlist is missing', async () => {
+    fetchSpy.mockResolvedValue(errorResponse(404));
+
+    await expect(client.getAllPlaylistTracks('deleted-playlist'))
+      .rejects.toMatchObject({ status: 404 });
+
+    await expect(client.getAllPlaylistTracks('deleted-playlist'))
+      .rejects.toThrow(/404/);
+  });
+
+  it('getAllPlaylistTracks throws SpotifyApiError(429) on rate limit', async () => {
+    fetchSpy.mockResolvedValue(errorResponse(429));
+
+    await expect(client.getAllPlaylistTracks('rate-limited'))
+      .rejects.toMatchObject({ status: 429 });
+  });
+
+  it('getAllPlaylistTracks does NOT crash with "items is undefined" on a 2xx Spotify error body', async () => {
+    // Spotify has historically returned 200 with `{ error: ... }` on some endpoints
+    fetchSpy.mockResolvedValue(jsonResponse({
+      error: { status: 404, message: 'Not found' },
+    }));
+
+    const tracks = await client.getAllPlaylistTracks('broken-playlist');
+    expect(tracks).toEqual([]);
+  });
+
+  it('getAllPlaylistTracks does NOT crash when response.items is missing', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      total: 0,
+      next: null,
+    }));
+
+    const tracks = await client.getAllPlaylistTracks('malformed-playlist');
+    expect(tracks).toEqual([]);
+  });
+
+  it('getAllSavedTracks does not crash when response.items is missing', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      total: 0,
+      next: null,
+    }));
+
+    const tracks = await client.getAllSavedTracks();
+    expect(tracks).toEqual([]);
+  });
+
+  it('getAllPlaylists does not crash when response.items is missing', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      total: 0,
+      next: null,
+    }));
+
+    const playlists = await client.getAllPlaylists();
+    expect(playlists).toEqual([]);
+  });
+
+  it('SpotifyApiError caps the stored body at MAX_ERROR_BODY_CHARS', async () => {
+    // Simulate a misbehaving CDN returning a giant HTML error page.
+    // The client retries 5xx up to 3 times, so each attempt needs a fresh
+    // Response (Response bodies are single-use).
+    const hugeBody = '<html>' + 'x'.repeat(20_000) + '</html>';
+    fetchSpy.mockImplementation(
+      () => Promise.resolve(new Response(hugeBody, {
+        status: 502,
+        headers: { 'Content-Type': 'text/html' },
+      })),
+    );
+
+    let caught: unknown;
+    try {
+      await client.getAllPlaylistTracks('broken-playlist');
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(SpotifyApiError);
+    const err = caught as SpotifyApiError;
+    expect(err.body.length).toBe(8 * 1024);
+    expect(err.bodyTruncated).toBe(true);
+    expect(err.bodyOriginalSize).toBe(hugeBody.length);
+    expect(err.message).toMatch(/truncated from \d+ to 8192 chars/);
+  });
+
+  it('SpotifyApiError keeps the body intact when under the cap', async () => {
+    fetchSpy.mockResolvedValue(errorResponse(403, {
+      error: { status: 403, message: 'Forbidden' },
+    }));
+
+    let caught: unknown;
+    try {
+      await client.getAllPlaylistTracks('forbidden-playlist');
+    } catch (e) {
+      caught = e;
+    }
+
+    const err = caught as SpotifyApiError;
+    expect(err.bodyTruncated).toBe(false);
+    expect(err.bodyOriginalSize).toBe(err.body.length);
+    expect(err.message).not.toMatch(/truncated/);
+  });
+
+  it('getAllPlaylistTracks normalizes legacy track objects (track instead of item)', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      items: [{ track: { id: 'legacy-t1' } }],
+      next: null,
+      total: 1,
+    }));
+
+    const tracks = await client.getAllPlaylistTracks('legacy-playlist');
+    expect(tracks).toHaveLength(1);
+    expect((tracks[0] as unknown as { track?: { id: string } }).track?.id).toBe('legacy-t1');
+  });
+
+  it('getAllPlaylistTracks stops paginating cleanly on empty page', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({
+        items: [{ item: { id: 't1' } }],
+        next: 'next-url',
+        total: 150,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        items: [],
+        next: null,
+        total: 150,
+      }));
+
+    const tracks = await client.getAllPlaylistTracks('playlist-with-empty-next');
+    expect(tracks).toHaveLength(1);
+  });
+
+  it('getPlaylistCreatedDate returns undefined (instead of crashing) on a non-array response.items', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      total: 0,
+      // items is missing entirely
+    }));
+
+    const result = await client.getPlaylistCreatedDate('broken-playlist');
+    expect(result).toBeUndefined();
+  });
+
+  it('getPlaylistTracks throws SpotifyApiError(400) for 4xx responses', async () => {
+    fetchSpy.mockResolvedValue(errorResponse(400, { error: { status: 400, message: 'Bad request' } }));
+
+    await expect(client.getPlaylistTracks('weird-playlist'))
+      .rejects.toBeInstanceOf(SpotifyApiError);
+
+    await expect(client.getPlaylistTracks('weird-playlist'))
+      .rejects.toMatchObject({ status: 400 });
   });
 });

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -1,10 +1,41 @@
-import { SpotifyPlaylistsResponse, SpotifyTracksResponse, SpotifyUser, SpotifyToken, SpotifyPlaylist, SpotifyPlaylistTrack, SpotifySavedTracksResponse, SpotifySavedTrack, SpotifyPlaylistEntry } from '@/types';
+import { SpotifyPlaylistsResponse, SpotifyTracksResponse, SpotifyUser, SpotifyToken, SpotifyPlaylist, SpotifyPlaylistTrack, SpotifySavedTracksResponse, SpotifySavedTrack, SpotifyPlaylistEntry, SpotifyTrack } from '@/types';
 import { isTokenExpired } from './token-storage';
 import { SPOTIFY_STORAGE_KEY } from '@/types/auth-context';
 import { spotifyRateLimiter, backgroundRateLimiter } from './rate-limiter';
 import { normalizeEntries } from './track-identity';
+import { log as debugLog } from '@/lib/support/debug-log';
 
 const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
+
+// Cap how much of an error body we keep. Spotify's JSON error payloads are
+// typically <500 bytes; 8 KB is plenty for diagnostics and bounded enough
+// that a misbehaving CDN returning a 5 MB HTML page can't bloat every error.
+const MAX_ERROR_BODY_CHARS = 8 * 1024;
+const ERROR_MESSAGE_BODY_CHARS = 200;
+
+export class SpotifyApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+  readonly bodyTruncated: boolean;
+  readonly bodyOriginalSize: number;
+
+  constructor(status: number, body: string) {
+    const originalSize = body.length;
+    const truncated = originalSize > MAX_ERROR_BODY_CHARS;
+    const stored = truncated ? body.slice(0, MAX_ERROR_BODY_CHARS) : body;
+    const truncationNote = truncated
+      ? ` (body truncated from ${originalSize} to ${MAX_ERROR_BODY_CHARS} chars)`
+      : '';
+    super(
+      `Spotify API error ${status}: ${stored.slice(0, ERROR_MESSAGE_BODY_CHARS)}${truncationNote}`,
+    );
+    this.name = 'SpotifyApiError';
+    this.status = status;
+    this.body = stored;
+    this.bodyTruncated = truncated;
+    this.bodyOriginalSize = originalSize;
+  }
+}
 
 export class SpotifyClient {
   private token: SpotifyToken | null = null;
@@ -37,13 +68,18 @@ export class SpotifyClient {
     await spotifyRateLimiter.acquire();
     const params = new URLSearchParams({ limit: limit.toString(), offset: offset.toString() });
     const response = await this.fetch(`/playlists/${playlistId}/items?${params.toString()}`, signal);
-    const data = await response.json();
-    if (data.items) {
-      data.items = data.items.map((i: Record<string, unknown>) => ({
+    const data: SpotifyTracksResponse = await response.json();
+    if (!Array.isArray(data.items)) {
+      data.items = [];
+    } else {
+      data.items = data.items.map((i) => ({
         ...i,
-        track: (i as Record<string, unknown>).item ?? i.track,
+        track: ((i as unknown as Record<string, unknown>).item as SpotifyTrack | null | undefined) ?? i.track,
       }));
     }
+    debugLog(
+      `getPlaylistTracks(${playlistId}, offset=${offset}) → ${data.items.length} items (total=${data.total})`,
+    );
     return data;
   }
 
@@ -54,6 +90,9 @@ export class SpotifyClient {
 
     while (true) {
       const response = await this.getPlaylistTracks(playlistId, limit, offset, signal);
+      if (!Array.isArray(response.items) || response.items.length === 0) {
+        break;
+      }
       allTracks.push(...response.items);
 
       if (!response.next) break;
@@ -88,6 +127,9 @@ export class SpotifyClient {
 
     while (true) {
       const response = await this.getSavedTracks(limit, offset, signal);
+      if (!Array.isArray(response.items) || response.items.length === 0) {
+        break;
+      }
       allTracks.push(...response.items);
 
       if (!response.next) break;
@@ -112,6 +154,9 @@ export class SpotifyClient {
 
     while (true) {
       const response = await this.getPlaylists(limit, offset, signal, bypassCache);
+      if (!Array.isArray(response.items) || response.items.length === 0) {
+        break;
+      }
       allPlaylists.push(...response.items);
 
       if (!response.next) break;
@@ -138,11 +183,12 @@ export class SpotifyClient {
       `/playlists/${playlistId}/items?fields=${fields}&limit=${limit}&offset=0`,
       signal,
     );
-    const firstData = await firstResponse.json();
+    const firstData: { items?: { added_at?: string }[]; total?: number } = await firstResponse.json();
+    if (!Array.isArray(firstData.items)) return undefined;
     const total: number = firstData.total || 0;
 
     let earliest: string | undefined;
-    for (const item of firstData.items || []) {
+    for (const item of firstData.items) {
       if (item.added_at) {
         if (!earliest || item.added_at < earliest) {
           earliest = item.added_at;
@@ -162,9 +208,10 @@ export class SpotifyClient {
       `/playlists/${playlistId}/items?fields=${fields}&limit=${limit}&offset=${lastOffset}`,
       signal,
     );
-    const lastData = await lastResponse.json();
+    const lastData: { items?: { added_at?: string }[] } = await lastResponse.json();
+    if (!Array.isArray(lastData.items)) return earliest;
 
-    for (const item of lastData.items || []) {
+    for (const item of lastData.items) {
       if (item.added_at) {
         if (!earliest || item.added_at < earliest) {
           earliest = item.added_at;
@@ -280,6 +327,7 @@ export class SpotifyClient {
     }
 
     let lastError: Error | null = null;
+    let lastBody = '';
     for (let attempt = 0; attempt < 3; attempt++) {
       const response = await fetch(`${SPOTIFY_API_BASE}${endpoint}`, fetchOptions);
 
@@ -292,13 +340,20 @@ export class SpotifyClient {
       }
 
       if (response.status >= 500 && response.status < 600) {
+        lastBody = await response.text().catch(() => '');
         lastError = new Error(`Spotify API error: ${response.status}`);
         if (attempt < 2) {
           const delay = Math.pow(2, attempt) * 1000;
           await new Promise(resolve => setTimeout(resolve, delay));
           continue;
         }
-        throw lastError;
+        throw new SpotifyApiError(response.status, lastBody);
+      }
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        debugLog(`${response.status} ${endpoint}`, body.slice(0, 300));
+        throw new SpotifyApiError(response.status, body);
       }
 
       return response;

--- a/lib/spotify/public-client.ts
+++ b/lib/spotify/public-client.ts
@@ -2,6 +2,7 @@ import https from 'node:https';
 import type { SpotifyTrack } from '@/types/spotify';
 import type { ImportedPlaylist } from '@/types/public-playlist';
 import { normalizeEntries } from './track-identity';
+import { log as debugLog } from '@/lib/support/debug-log';
 
 const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
 const SPOTIFY_AUTH_BASE = 'https://accounts.spotify.com/api/token';
@@ -159,10 +160,21 @@ export async function getPublicPlaylist(
   let nullTrackCount = 0;
   let nextPath: string | null =
     `/playlists/${playlistId}/items?fields=items(item(id,name,artists(id,name),album(id,name,release_date),duration_ms,external_ids,external_urls,uri,is_local),is_local,added_at),next,snapshot_id&limit=50`;
+  debugLog(
+    `getPublicPlaylist(${playlistId}) meta:`,
+    { name: meta.name, owner: meta.owner.display_name, total: meta.tracks.total },
+  );
+  let pageCount = 0;
   while (nextPath) {
     const page: PlaylistTracksPage = await spotifyGet<PlaylistTracksPage>(token, nextPath);
+    pageCount += 1;
+    if (!Array.isArray(page.items)) {
+      debugLog(`  page ${pageCount}: items missing, stopping pagination`);
+      break;
+    }
+    debugLog(`  page ${pageCount}: ${page.items.length} items`);
     for (const item of page.items) {
-      const itemData = (item as Record<string, unknown>).item as SpotifyTrack | null;
+      const itemData = (item as unknown as Record<string, unknown>).item as SpotifyTrack | null;
       const track = itemData ?? item.track;
       if (track) {
         if (item.is_local) {

--- a/lib/support/debug-log.ts
+++ b/lib/support/debug-log.ts
@@ -1,0 +1,52 @@
+/**
+ * Lightweight verbose logger for debugging. Gated by:
+ *   1. NODE_ENV !== 'production', OR
+ *   2. localStorage flag `navispot.debug` === 'true'
+ *
+ * Use `log()` / `warn()` / `error()` instead of console.* directly so we can
+ * ship to production without noise. Lines are prefixed with `[navispot]`
+ * so users can filter their DevTools console.
+ */
+
+const STORAGE_KEY = 'navispot.debug';
+
+function isEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'production') return true;
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function emit(level: 'log' | 'warn' | 'error', args: unknown[]): void {
+  if (!isEnabled()) return;
+  console[level]('[navispot]', ...args);
+}
+
+export const log = (...args: unknown[]): void => emit('log', args);
+export const warn = (...args: unknown[]): void => emit('warn', args);
+export const error = (...args: unknown[]): void => emit('error', args);
+
+export function enableDebug(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, 'true');
+  } catch {
+    /* ignore */
+  }
+}
+
+export function disableDebug(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function isDebugEnabled(): boolean {
+  return isEnabled();
+}


### PR DESCRIPTION
## Summary

Fixes the cryptic `TypeError: can't access property Symbol.iterator, n.items is undefined` crash from issue #9 (and any future report with the same shape).

The root cause: `SpotifyClient.fetch` only handled 401 and 5xx, silently passing 403/404/429 through. Downstream code (`getAllPlaylistTracks`, etc.) then did `allTracks.push(...response.items)` on `undefined` and crashed. Same vulnerable pattern existed in `getAllSavedTracks`, `getAllPlaylists`, and the public-client pagination loop.

## Changes

**`lib/spotify/client.ts`**
- New typed `SpotifyApiError` class carrying `status`, `body` (capped at 8 KB), `bodyTruncated`, `bodyOriginalSize`
- `fetch()` throws `SpotifyApiError` on any non-2xx (after the 401-refresh and 5xx-retry paths); preserves the body across retry attempts
- `Array.isArray` guards added to `getAllPlaylistTracks`, `getAllSavedTracks`, `getAllPlaylists`

**`lib/spotify/public-client.ts`**
- Same `Array.isArray` guard in the pagination loop
- Fix pre-existing TS cast at line 165

**`lib/support/debug-log.ts` (new)**
- Gated logger: on in dev, or in prod via `localStorage.setItem('navispot.debug', 'true')`
- Surfaces request URLs, response status, body previews, stack traces at the high-value failure sites

**`components/Dashboard/Dashboard.tsx`**
- Logs the full error object (including `SpotifyApiError.body`) when export fails

## Tests

12 new regression tests in `lib/spotify/client-endpoint.test.ts` covering: 403/404/429 throws, 200 with missing/empty `items`, legacy `{ track }` shape, empty pagination, malformed JSON, body-cap truncation, and body preservation under the cap.

## What users see now

Instead of `TypeError: can't access property Symbol.iterator, n.items is undefined`:
- An honest error like `Spotify API error 403: {"error":{"status":403,"message":"..."}}`
- The status + body in the DevTools console via `[navispot]` log lines

## Test plan

- [x] `pnpm test` — 67/67 pass
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm lint` — same 29 pre-existing issues, 0 new
- [x] `pnpm build` — succeeds

Fixes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Spotify playlist and track import reliability when responses are incomplete, malformed, or use legacy track formats.
  - Added clearer handling for Spotify errors, including rate limits, missing playlists, authorization failures, and oversized error responses.
  - Prevented pagination from continuing unnecessarily when empty or invalid pages are returned.
  - Improved playlist creation-date parsing for incomplete data.

- **Improvements**
  - Added optional debug logging to help diagnose export and playlist import issues during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->