### PR TITLE
feat(debug): split logger into info/warn/error and surface silent-empty anomalies

### DIFF
--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -8,7 +8,7 @@ import { SpotifyPlaylist, SpotifyTrack } from "@/types/spotify"
 import { NavidromePlaylist } from "@/types/navidrome"
 import { PlaylistTable } from "@/components/Dashboard/PlaylistTable"
 import { ExportLayoutManager } from "@/components/Dashboard/ExportLayoutManager"
-import { log } from "@/lib/support/debug-log"
+import { error as logError } from "@/lib/support/debug-log"
 
 import { ConfirmationPopup } from "@/components/Dashboard/ConfirmationPopup"
 import { CancelConfirmationDialog } from "@/components/Dashboard/CancelConfirmationDialog"
@@ -1596,7 +1596,7 @@ export function Dashboard() {
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "Export failed"
-      log('export failed:', err)
+      logError('export failed:', err)
 
       if (err instanceof DOMException && err.name === 'AbortError') {
         toast.showWarning("Export was cancelled")

--- a/lib/spotify/client.ts
+++ b/lib/spotify/client.ts
@@ -3,7 +3,7 @@ import { isTokenExpired } from './token-storage';
 import { SPOTIFY_STORAGE_KEY } from '@/types/auth-context';
 import { spotifyRateLimiter, backgroundRateLimiter } from './rate-limiter';
 import { normalizeEntries } from './track-identity';
-import { log as debugLog } from '@/lib/support/debug-log';
+import { info as debugLog, warn } from '@/lib/support/debug-log';
 
 const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
 
@@ -80,6 +80,11 @@ export class SpotifyClient {
     debugLog(
       `getPlaylistTracks(${playlistId}, offset=${offset}) → ${data.items.length} items (total=${data.total})`,
     );
+    if (data.total > 0 && data.items.length === 0) {
+      warn(
+        `getPlaylistTracks(${playlistId}, offset=${offset}): Spotify says total=${data.total} but returned 0 items`,
+      );
+    }
     return data;
   }
 

--- a/lib/spotify/public-client.ts
+++ b/lib/spotify/public-client.ts
@@ -2,7 +2,7 @@ import https from 'node:https';
 import type { SpotifyTrack } from '@/types/spotify';
 import type { ImportedPlaylist } from '@/types/public-playlist';
 import { normalizeEntries } from './track-identity';
-import { log as debugLog } from '@/lib/support/debug-log';
+import { info as debugLog, warn } from '@/lib/support/debug-log';
 
 const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
 const SPOTIFY_AUTH_BASE = 'https://accounts.spotify.com/api/token';
@@ -169,7 +169,7 @@ export async function getPublicPlaylist(
     const page: PlaylistTracksPage = await spotifyGet<PlaylistTracksPage>(token, nextPath);
     pageCount += 1;
     if (!Array.isArray(page.items)) {
-      debugLog(`  page ${pageCount}: items missing, stopping pagination`);
+      warn(`getPublicPlaylist(${playlistId}) page ${pageCount}: items array missing in response`);
       break;
     }
     debugLog(`  page ${pageCount}: ${page.items.length} items`);

--- a/lib/support/debug-log.ts
+++ b/lib/support/debug-log.ts
@@ -1,52 +1,21 @@
 /**
- * Lightweight verbose logger for debugging. Gated by:
- *   1. NODE_ENV !== 'production', OR
- *   2. localStorage flag `navispot.debug` === 'true'
+ * Lightweight logger for the four high-value failure sites. Lines are prefixed
+ * with `[navispot]` so users can filter their DevTools console and paste the
+ * filtered output when reporting issues.
  *
- * Use `log()` / `warn()` / `error()` instead of console.* directly so we can
- * ship to production without noise. Lines are prefixed with `[navispot]`
- * so users can filter their DevTools console.
+ * Levels:
+ *   - info()  routine breadcrumbs (dev mode only — keeps the live demo console quiet)
+ *   - warn()  anomalies (always on — useful in production for reports)
+ *   - error() thrown failures (always on)
  */
 
-const STORAGE_KEY = 'navispot.debug';
+const isDev = (): boolean => process.env.NODE_ENV !== 'production';
 
-function isEnabled(): boolean {
-  if (process.env.NODE_ENV !== 'production') return true;
-  if (typeof window === 'undefined') return false;
-  try {
-    return window.localStorage.getItem(STORAGE_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
-
-function emit(level: 'log' | 'warn' | 'error', args: unknown[]): void {
-  if (!isEnabled()) return;
+function emit(level: 'log' | 'warn' | 'error', args: unknown[], always: boolean): void {
+  if (!always && !isDev()) return;
   console[level]('[navispot]', ...args);
 }
 
-export const log = (...args: unknown[]): void => emit('log', args);
-export const warn = (...args: unknown[]): void => emit('warn', args);
-export const error = (...args: unknown[]): void => emit('error', args);
-
-export function enableDebug(): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, 'true');
-  } catch {
-    /* ignore */
-  }
-}
-
-export function disableDebug(): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    /* ignore */
-  }
-}
-
-export function isDebugEnabled(): boolean {
-  return isEnabled();
-}
+export const info = (...args: unknown[]): void => emit('log', args, false);
+export const warn = (...args: unknown[]): void => emit('warn', args, true);
+export const error = (...args: unknown[]): void => emit('error', args, true);


### PR DESCRIPTION
Follow-up to #25.

- `info()`: dev-only routine breadcrumbs (per-page counts, metadata)
- `warn()`: always on — silent-empty anomalies surface in production
- `error()`: always on — full stack traces

Promoted two cases from `info` to `warn` so they show up on the live demo without any opt-in:
- `getPlaylistTracks`: warns when `Spotify says total=N but returned 0 items` (the silent-empty case that originally masked itself behind the cryptic Symbol.iterator crash)
- `getPublicPlaylist`: warns when the `items` array is missing from a response page

Drops the `navispot.debug` localStorage flag entirely — production users now get diagnostic info by default; the only thing gated is dev-mode breadcrumbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when playlist exports fail.
  * Added clearer warnings when playlist data is incomplete or unexpectedly empty.
  * Ensured important warnings and errors remain visible in production.
* **Refactor**
  * Simplified diagnostic logging behavior for more consistent troubleshooting.
  * Routine development messages are now limited to non-production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->