### PR TITLE
feat(navidrome): add public/private toggle for exported playlists

### DIFF
--- a/components/Dashboard/Dashboard.tsx
+++ b/components/Dashboard/Dashboard.tsx
@@ -46,6 +46,8 @@ import {
 import {
   loadForceExportPlaylists,
   saveForceExportPlaylists,
+  loadExportPlaylistsAsPublic,
+  saveExportPlaylistsAsPublic,
 } from "@/lib/settings/export-settings"
 import {
   loadPlaylistExportData,
@@ -136,6 +138,8 @@ export function Dashboard() {
   const [forceExportPlaylists, setForceExportPlaylists] = useState<boolean>(() =>
     loadForceExportPlaylists(),
   )
+  const [exportPlaylistsAsPublic, setExportPlaylistsAsPublic] =
+    useState<boolean>(() => loadExportPlaylistsAsPublic())
   const [currentUnmatchedPlaylistId, setCurrentUnmatchedPlaylistId] = useState<
     string | null
   >(null)
@@ -1306,6 +1310,21 @@ export function Dashboard() {
 
         // Skip unchanged playlists entirely (no tracks added/removed)
         if (upToDate && existingNavidromeId && !forceExportPlaylists && !isLikedSongs) {
+          // Tracks didn't change, but the user's visibility preference may have
+          // since been toggled — apply it directly so the on-disk state matches
+          // the current setting. The exporter would normally do this, but the
+          // early-return skips it.
+          const visibilityResult = await navidromeClient.updatePlaylistVisibility(
+            existingNavidromeId,
+            exportPlaylistsAsPublic,
+            signal,
+          )
+          if (!visibilityResult.success) {
+            toast.showWarning(
+              `Couldn't update visibility for "${item.name}": ${visibilityResult.error || "Unknown error"}`,
+            )
+          }
+
           exportResultData = {
             statistics: {
               total: tracks.length,
@@ -1441,6 +1460,7 @@ export function Dashboard() {
             existingPlaylistId:
               !forceCreate ? cachedData?.navidromePlaylistId : undefined,
             skipUnmatched: false,
+            isPublic: exportPlaylistsAsPublic,
             cachedData:
               !forceCreate && useDifferentialMatching ? cachedData : undefined,
             signal,
@@ -1646,6 +1666,11 @@ export function Dashboard() {
   const handleForceExportChange = useCallback((enabled: boolean) => {
     setForceExportPlaylists(enabled)
     saveForceExportPlaylists(enabled)
+  }, [])
+
+  const handleExportPlaylistsAsPublicChange = useCallback((isPublic: boolean) => {
+    setExportPlaylistsAsPublic(isPublic)
+    saveExportPlaylistsAsPublic(isPublic)
   }, [])
 
   const handleConfirmCancel = () => {
@@ -1927,6 +1952,8 @@ export function Dashboard() {
         onLayoutChange={handleLayoutChange}
         forceExportPlaylists={forceExportPlaylists}
         onForceExportChange={handleForceExportChange}
+        exportPlaylistsAsPublic={exportPlaylistsAsPublic}
+        onExportPlaylistsAsPublicChange={handleExportPlaylistsAsPublicChange}
       />
       
       <ExportLayoutManager

--- a/components/Dashboard/SettingsModal.tsx
+++ b/components/Dashboard/SettingsModal.tsx
@@ -16,6 +16,8 @@ interface SettingsModalProps {
   onLayoutChange: (layout: DashboardLayout) => void
   forceExportPlaylists: boolean
   onForceExportChange: (enabled: boolean) => void
+  exportPlaylistsAsPublic: boolean
+  onExportPlaylistsAsPublicChange: (isPublic: boolean) => void
 }
 
 type SettingsSection = "data" | "layout" | "export"
@@ -39,6 +41,8 @@ export function SettingsModal({
   onLayoutChange,
   forceExportPlaylists,
   onForceExportChange,
+  exportPlaylistsAsPublic,
+  onExportPlaylistsAsPublicChange,
 }: SettingsModalProps) {
   const { navidrome } = useAuth()
   const [activeSection, setActiveSection] = useState<SettingsSection>("data")
@@ -439,6 +443,42 @@ export function SettingsModal({
                         aria-hidden="true"
                         className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform ${
                           forceExportPlaylists
+                            ? "translate-x-5"
+                            : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                        Export playlists as public
+                      </h4>
+                      <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                        New and updated playlists are marked as public in
+                        Navidrome. When off, they remain private
+                        (Navidrome&apos;s default).
+                      </p>
+                    </div>
+                    <button
+                      role="switch"
+                      aria-checked={exportPlaylistsAsPublic}
+                      onClick={() =>
+                        onExportPlaylistsAsPublicChange(!exportPlaylistsAsPublic)
+                      }
+                      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+                        exportPlaylistsAsPublic
+                          ? "bg-green-500"
+                          : "bg-zinc-200 dark:bg-zinc-700"
+                      }`}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform ${
+                          exportPlaylistsAsPublic
                             ? "translate-x-5"
                             : "translate-x-0"
                         }`}

--- a/lib/export/playlist-exporter.ts
+++ b/lib/export/playlist-exporter.ts
@@ -61,6 +61,7 @@ export interface PlaylistExporterOptions {
   mode?: ExportMode;
   existingPlaylistId?: string;
   skipUnmatched?: boolean;
+  isPublic?: boolean;
   onProgress?: ProgressCallback;
   cachedData?: PlaylistExportDataLocal | PlaylistExportData | PlaylistExportDataV2;
   signal?: AbortSignal;
@@ -72,7 +73,7 @@ export interface PlaylistExporter {
     matches: TrackMatch[],
     options?: PlaylistExporterOptions
   ): Promise<ExportResult>;
-  createPlaylist(name: string, songIds: string[]): Promise<{ id: string; success: boolean }>;
+  createPlaylist(name: string, songIds: string[], isPublic?: boolean): Promise<{ id: string; success: boolean }>;
   appendToPlaylist(playlistId: string, songIds: string[]): Promise<{ success: boolean }>;
   overwritePlaylist(playlistId: string, songIds: string[]): Promise<{ success: boolean }>;
 }
@@ -92,6 +93,7 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
     const startTime = Date.now();
     const mode = options.mode ?? 'create';
     const skipUnmatched = options.skipUnmatched ?? false;
+    const isPublic = options.isPublic ?? false;
     const onProgress = options.onProgress;
     const { signal } = options;
 
@@ -165,7 +167,7 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
       switch (mode) {
         case 'create': {
           checkAbort();
-          const createResult = await this.createPlaylist(playlistName, songIds, signal);
+          const createResult = await this.createPlaylist(playlistName, songIds, isPublic, signal);
           if (!createResult.success || !createResult.id) {
             errors.push({
               trackName: 'N/A',
@@ -283,6 +285,22 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
       });
     }
 
+    // Apply the user's visibility preference. For 'create' this was already set
+    // on the new playlist; for 'append'/'overwrite'/'update' we PATCH it onto
+    // the existing playlist. Errors here are non-fatal — tracks are exported
+    // either way, only the visibility may be left unchanged.
+    if (playlistId) {
+      checkAbort();
+      const visibilityResult = await this.navidromeClient.updatePlaylistVisibility(playlistId, isPublic, signal);
+      if (!visibilityResult.success) {
+        errors.push({
+          trackName: 'N/A',
+          artistName: 'N/A',
+          reason: `Failed to set playlist visibility: ${visibilityResult.error || 'Unknown error'}`,
+        });
+      }
+    }
+
     if (onProgress) {
       checkAbort();
       await onProgress({
@@ -311,8 +329,8 @@ export class DefaultPlaylistExporter implements PlaylistExporter {
     };
   }
 
-  async createPlaylist(name: string, songIds: string[], signal?: AbortSignal): Promise<{ id: string; success: boolean }> {
-    const result = await this.navidromeClient.createPlaylist(name, songIds, signal);
+  async createPlaylist(name: string, songIds: string[], isPublic: boolean = false, signal?: AbortSignal): Promise<{ id: string; success: boolean }> {
+    const result = await this.navidromeClient.createPlaylist(name, songIds, isPublic, signal);
     return {
       id: result.id,
       success: result.success,

--- a/lib/navidrome/client.ts
+++ b/lib/navidrome/client.ts
@@ -856,13 +856,9 @@ export class NavidromeApiClient {
     const comment = JSON.stringify(metadata);
     const url = `${this.baseUrl}/api/playlist/${playlistId}`;
     const response = await fetch(url, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-nd-authorization': `Bearer ${this._ndToken}`,
-        'x-nd-client-unique-id': `${this._ndClientId}`,
-      },
-      body: JSON.stringify({ comment }),
+      method: 'PUT',
+      headers: this._getNativeHeaders(),
+      body: JSON.stringify({ id: playlistId, comment }),
       signal,
     });
 

--- a/lib/navidrome/client.ts
+++ b/lib/navidrome/client.ts
@@ -310,7 +310,7 @@ export class NavidromeApiClient {
     };
   }
 
-  async createPlaylist(name: string, songIds: string[], signal?: AbortSignal): Promise<{
+  async createPlaylist(name: string, songIds: string[], isPublic: boolean = false, signal?: AbortSignal): Promise<{
     id: string;
     success: boolean;
     error?: string;
@@ -324,7 +324,7 @@ export class NavidromeApiClient {
           'x-nd-authorization': `Bearer ${this._ndToken}`,
           'x-nd-client-unique-id': `${this._ndClientId}`,
         },
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name, public: isPublic }),
         signal,
       });
 
@@ -871,6 +871,30 @@ export class NavidromeApiClient {
     }
   }
 
+  async updatePlaylistVisibility(playlistId: string, isPublic: boolean, signal?: AbortSignal): Promise<{ success: boolean; error?: string }> {
+    await this._ensureAuthenticated();
+    try {
+      const url = `${this.baseUrl}/api/playlist/${playlistId}`;
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: this._getNativeHeaders(),
+        body: JSON.stringify({ id: playlistId, public: isPublic }),
+        signal,
+      });
+
+      if (!response.ok) {
+        return { success: false, error: `HTTP error: ${response.status} ${response.statusText}` };
+      }
+
+      return { success: true };
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw error;
+      }
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
   async findOrCreateLikedSongsPlaylist(spotifyPlaylistId: string, trackCount: number): Promise<NavidromePlaylist> {
     const existingPlaylist = await this.getPlaylistByComment(spotifyPlaylistId);
 
@@ -925,6 +949,7 @@ export class NavidromeApiClient {
       duration: item.duration,
       createdAt: item.createdAt || '',
       updatedAt: item.updatedAt || '',
+      public: item.public,
     };
   }
 }

--- a/lib/settings/export-settings.ts
+++ b/lib/settings/export-settings.ts
@@ -1,4 +1,5 @@
 const FORCE_EXPORT_STORAGE_KEY = "navispot-force-export-playlists";
+const PUBLIC_PLAYLISTS_STORAGE_KEY = "navispot-export-playlists-public";
 
 export function loadForceExportPlaylists(): boolean {
   if (typeof window === "undefined") return false;
@@ -14,6 +15,25 @@ export function saveForceExportPlaylists(enabled: boolean): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(FORCE_EXPORT_STORAGE_KEY, String(enabled));
+  } catch {
+    // Ignore
+  }
+}
+
+export function loadExportPlaylistsAsPublic(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const stored = window.localStorage.getItem(PUBLIC_PLAYLISTS_STORAGE_KEY);
+    return stored === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function saveExportPlaylistsAsPublic(isPublic: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PUBLIC_PLAYLISTS_STORAGE_KEY, String(isPublic));
   } catch {
     // Ignore
   }

--- a/types/navidrome.ts
+++ b/types/navidrome.ts
@@ -6,6 +6,7 @@ export interface NavidromePlaylist {
   duration: number;
   createdAt: string;
   updatedAt: string;
+  public?: boolean;
 }
 
 export interface NavidromeCredentials {


### PR DESCRIPTION
## Summary

Adds a "Export playlists as public" toggle in Settings → Export. When on, playlists created or updated during export are marked public in Navidrome via the native `PUT /api/playlist/{id}` endpoint; when off, they remain private (Navidromes default).

## Whats in this PR

**Commit 1 — `feat(navidrome): add public/private toggle for exported playlists`**
- New `public?: boolean` field on the `NavidromePlaylist` type
- `NavidromeApiClient.createPlaylist` accepts and sends `public` on creation
- New `NavidromeApiClient.updatePlaylistVisibility` that uses native `PUT` on `/api/playlist/{id}`
- `PlaylistExporter` reads `isPublic` from its options and applies it in all modes (create / append / overwrite / update); the visibility PATCH is non-fatal — track errors win, visibility issues are surfaced as warnings
- New `loadExportPlaylistsAsPublic` / `saveExportPlaylistsAsPublic` localStorage helpers (default off)
- New toggle in `SettingsModal` → Export tab
- `Dashboard.tsx` wires the setting through and, importantly, also applies it on the up-to-date early-return path so toggling the setting retroactively syncs the on-disk state without requiring a track change

**Commit 2 — `fix(navidrome): switch updatePlaylistComment from PATCH to PUT`**
The native `/api/playlist/{id}` endpoint only registers `PUT`, not PATCH (per `server/nativeapi/native_api.go:123`). The existing `updatePlaylistComment` was using `PATCH`, which silently 405d and broke metadata updates on the Liked Songs playlist. Switched to `PUT` with the native auth headers and an `{ id, comment }` body, matching the `rest.Put` contract.

## Verified

- `tsc --noEmit` clean
- `vitest run` — 67/67 tests pass
- `eslint` — no new issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to export Navidrome playlists as public or private.
  * Saved the visibility preference for future exports.
  * Applied visibility changes to existing playlists, including playlists whose tracks are already up to date.
* **Bug Fixes**
  * Improved playlist metadata updates and reported non-blocking visibility update failures without interrupting exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->